### PR TITLE
Add unit tests for drivers and control logic

### DIFF
--- a/microstage_app/tests/__init__.py
+++ b/microstage_app/tests/__init__.py
@@ -1,0 +1,2 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))

--- a/microstage_app/tests/test_autofocus.py
+++ b/microstage_app/tests/test_autofocus.py
@@ -1,0 +1,25 @@
+import microstage_app.control.autofocus as af
+from microstage_app.control.autofocus import AutoFocus, FocusMetric
+
+class StageMock:
+    def __init__(self):
+        self.z = 0.0
+        self.moves = []
+    def move_relative(self, dz=0.0, feed_mm_per_min=0.0):
+        self.z += dz
+        self.moves.append(dz)
+    def wait_for_moves(self):
+        pass
+
+class CameraMock:
+    def snap(self):
+        return object()
+
+
+def test_autofocus_converges(monkeypatch):
+    stage = StageMock()
+    cam = CameraMock()
+    monkeypatch.setattr(af, 'metric_value', lambda img, metric: -abs(stage.z))
+    autofocus = AutoFocus(stage, cam)
+    best = autofocus.coarse_to_fine(FocusMetric.LAPLACIAN, z_range_mm=0.2, coarse_step_mm=0.1, fine_step_mm=0.05)
+    assert abs(best) < 1e-6

--- a/microstage_app/tests/test_camera_driver.py
+++ b/microstage_app/tests/test_camera_driver.py
@@ -1,0 +1,21 @@
+import types
+from microstage_app.devices import camera_toupcam
+from microstage_app.devices.camera_mock import MockCamera
+
+
+def test_create_camera_no_devices(monkeypatch):
+    class DummyTP:
+        class Toupcam:
+            @staticmethod
+            def EnumV2():
+                return []
+    monkeypatch.setattr(camera_toupcam, '_import_toupcam', lambda: DummyTP)
+    cam = camera_toupcam.create_camera()
+    assert isinstance(cam, MockCamera)
+
+
+def test_mock_camera_snap_shape():
+    cam = MockCamera()
+    img = cam.snap()
+    assert img.shape == (480, 640, 3)
+    assert img.dtype.name == 'uint8'

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -1,0 +1,33 @@
+from microstage_app.control.raster import RasterRunner, RasterConfig
+
+class StageMock:
+    def __init__(self):
+        self.moves = []
+    def move_relative(self, dx=0.0, dy=0.0, dz=0.0):
+        self.moves.append((dx, dy, dz))
+    def wait_for_moves(self):
+        pass
+
+class CameraMock:
+    def __init__(self):
+        self.count = 0
+    def snap(self):
+        self.count += 1
+        return self.count
+
+class WriterMock:
+    def __init__(self):
+        self.saved = []
+    def save_tile(self, img, r, c):
+        self.saved.append((img, r, c))
+
+
+def test_raster_serpentine(monkeypatch):
+    stage = StageMock()
+    cam = CameraMock()
+    writer = WriterMock()
+    cfg = RasterConfig(rows=2, cols=3, pitch_x_mm=1.0, pitch_y_mm=1.0, serpentine=True)
+    runner = RasterRunner(stage, cam, writer, cfg)
+    runner.run()
+    assert writer.saved == [(1,0,0),(2,0,1),(3,0,2),(4,1,0),(5,1,1),(6,1,2)]
+    assert stage.moves == [(0.0,1.0,0.0),(-2.0,0.0,0.0),(-2.0,0.0,0.0)]

--- a/microstage_app/tests/test_stage_driver.py
+++ b/microstage_app/tests/test_stage_driver.py
@@ -1,0 +1,31 @@
+import serial
+from microstage_app.devices.stage_marlin import StageMarlin
+
+class DummySerial:
+    def __init__(self, *args, **kwargs):
+        self.writes = []
+    def write(self, data):
+        self.writes.append(data.decode())
+    def read(self, n):
+        return b''
+    def readline(self):
+        return b'ok\n'
+    def reset_input_buffer(self):
+        pass
+
+
+def test_move_commands(monkeypatch):
+    dummy = DummySerial()
+    monkeypatch.setattr(serial, 'Serial', lambda *a, **k: dummy)
+    stage = StageMarlin('COMX')
+    dummy.writes.clear()
+    stage.move_relative(dx=1.0, dy=-2.0, dz=0.5, feed_mm_per_min=123, wait_ok=True)
+    assert dummy.writes[0].strip() == 'G91'
+    cmd = dummy.writes[1]
+    assert 'X1.0000' in cmd and 'Y-2.0000' in cmd and 'Z0.5000' in cmd and 'F123.00' in cmd
+    assert dummy.writes[2].strip() == 'G90'
+    dummy.writes.clear()
+    stage.move_absolute(x=2.0, z=-1.0, feed_mm_per_min=150, wait_ok=True)
+    assert dummy.writes[0].strip() == 'G90'
+    cmd = dummy.writes[1]
+    assert cmd.startswith('G1') and 'X2.0000' in cmd and 'Z-1.0000' in cmd and 'F150.00' in cmd


### PR DESCRIPTION
## Summary
- Add mock-based unit tests for stage and camera drivers
- Test autofocus convergence using staged camera metrics
- Validate raster scanning order and stage movements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f0a71d888324906f3b96763f798f