### PR TITLE
Verify Marlin stage by machine name and UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
 > No camera? The app falls back to a software **MockCamera** so you can test UI and scans.
 
 ## Features
-- Device discovery: auto-detects Marlin via `M115` and ToupCam via SDK enumerate.
+- Device discovery: auto-detects Marlin via `M115` (verifying custom machine name and optional UUID) and ToupCam via SDK enumerate.
 - Live preview + jog controls (XY/Z), home, go-to.
 - Capture primitives: move → settle → snap.
 - Modes: Timelapse, Raster (serpentine), Combined.

--- a/README.txt
+++ b/README.txt
@@ -78,7 +78,9 @@ QUICK START
 4) Diagnostics
    python -m microstage_app.tools.diagnose
 
-Ports & baud: We probe for Marlin by opening the COM port at 250000 and sending M115 to find 'FIRMWARE_NAME:Marlin'. If that fails, try 115200.
+Ports & baud: We probe for Marlin by opening the COM port at 250000 and sending M115 to find
+    'FIRMWARE_NAME:Marlin' and the expected MACHINE_NAME. If a MACHINE_UUID is provided, it is used
+    to choose between multiple compatible boards. If that fails, try 115200.
 
 --------------------------------------------------------------------------
 USING THE APP
@@ -129,7 +131,7 @@ THREADING & SAFETY
 --------------------------------------------------------------------------
 MARLIN PROTOCOL QUICK REF
 --------------------------------------------------------------------------
-- Probe: M115 -> parse 'FIRMWARE_NAME:Marlin' to confirm device.
+- Probe: M115 -> parse 'FIRMWARE_NAME:Marlin' and custom MACHINE_NAME to confirm device (UUID optional).
 - Home: G28 (all axes by default).
 - Jog (relative): G91 -> G1 X/Y/Z... F... -> G90 (feed in mm/min).
 - Wait: M400 before capture/critical sequencing.

--- a/microstage_app/config.py
+++ b/microstage_app/config.py
@@ -1,0 +1,11 @@
+import os
+
+# Expected identifiers for the Marlin-based stage board.
+# `EXPECTED_MACHINE_NAME` is the primary guard that ensures we only talk to
+# a board flashed with the custom firmware. `EXPECTED_MACHINE_UUID` is optional
+# and helps disambiguate between multiple compatible boards.
+EXPECTED_MACHINE_NAME = os.getenv("MICROSTAGE_MACHINE_NAME", "MicroStageController")
+EXPECTED_MACHINE_UUID = os.getenv(
+    "MICROSTAGE_MACHINE_UUID",
+    "a3a4637a-68c4-4340-9fda-847b4fe0d3fc",
+)

--- a/microstage_app/tests/test_stage_probe.py
+++ b/microstage_app/tests/test_stage_probe.py
@@ -1,5 +1,163 @@
+import serial
+import serial.tools.list_ports
+from microstage_app.devices.stage_marlin import find_marlin_port
+
+
 def test_no_ports(monkeypatch):
-    import serial.tools.list_ports
-    from microstage_app.devices.stage_marlin import find_marlin_port
     monkeypatch.setattr(serial.tools.list_ports, "comports", lambda: [])
     assert find_marlin_port() is None
+
+
+def test_identifiers_match(monkeypatch):
+    from microstage_app.devices import stage_marlin
+
+    class Port:
+        device = "COMX"
+        vid = 0x1A86
+        pid = 0x7523
+
+    class DummySerial:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, data):
+            pass
+
+        def read(self, n):
+            return (
+                b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n"
+            )
+
+    monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [Port()])
+    monkeypatch.setattr(stage_marlin.serial, "Serial", DummySerial)
+    monkeypatch.setattr(stage_marlin.time, "sleep", lambda x: None)
+
+    assert find_marlin_port() == "COMX"
+
+
+def test_machine_name_mismatch(monkeypatch):
+    from microstage_app.devices import stage_marlin
+
+    class Port:
+        device = "COMY"
+        vid = 0x1A86
+        pid = 0x7523
+
+    class DummySerial:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, data):
+            pass
+
+        def read(self, n):
+            return b"FIRMWARE_NAME:Marlin MACHINE_NAME:Other UUID:0000\nok\n"
+
+    monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [Port()])
+    monkeypatch.setattr(stage_marlin.serial, "Serial", DummySerial)
+    monkeypatch.setattr(stage_marlin.time, "sleep", lambda x: None)
+
+    assert find_marlin_port() is None
+
+
+def test_uuid_mismatch_still_accepts(monkeypatch):
+    from microstage_app.devices import stage_marlin
+
+    class Port:
+        device = "COMY"
+        vid = 0x1A86
+        pid = 0x7523
+
+    class DummySerial:
+        def __init__(self, *a, **k):
+            pass
+
+        # Use context manager methods to support 'with'
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, data):
+            pass
+
+        def read(self, n):
+            return b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:0000\nok\n"
+
+    monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [Port()])
+    monkeypatch.setattr(stage_marlin.serial, "Serial", DummySerial)
+    monkeypatch.setattr(stage_marlin.time, "sleep", lambda x: None)
+
+    assert find_marlin_port() == "COMY"
+
+
+def test_prefers_uuid_when_multiple(monkeypatch):
+    from microstage_app.devices import stage_marlin
+
+    class PortA:
+        device = "COMA"
+        vid = 0x1A86
+        pid = 0x7523
+
+    class PortB:
+        device = "COMB"
+        vid = 0x1A86
+        pid = 0x7523
+
+    responses = {
+        "COMA": b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:0000\nok\n",
+        "COMB": b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n",
+    }
+
+    class DummySerial:
+        def __init__(self, port, *a, **k):
+            self.port = port
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, data):
+            pass
+
+        def read(self, n):
+            return responses[self.port]
+
+    monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [PortA(), PortB()])
+    monkeypatch.setattr(stage_marlin.serial, "Serial", DummySerial)
+    monkeypatch.setattr(stage_marlin.time, "sleep", lambda x: None)
+
+    assert (
+        find_marlin_port(
+            machine_name="MicroStageController",
+            machine_uuid="a3a4637a-68c4-4340-9fda-847b4fe0d3fc",
+        )
+        == "COMB"
+    )


### PR DESCRIPTION
## Summary
- Require custom machine name to identify compatible Marlin stage boards
- Prefer matching UUID but fall back to any board with the correct name
- Document the machine-name-first behavior and extend diagnostics and tests

## Testing
- `apt-get install -y libgl1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e95662988324a3bb0c1483611ff5