### PR TITLE
Handle camera close errors in diagnostics

### DIFF
--- a/microstage_app/tools/diagnose.py
+++ b/microstage_app/tools/diagnose.py
@@ -88,8 +88,11 @@ def main():
                 except Exception as e:
                     log('[ERR] StartPullModeWithCallback failed:', e)
                 finally:
-                    try: cam.Close()
-                    except Exception: pass
+                    try:
+                        cam.Close()
+                    except Exception as e:
+                        log('[WARN] camera close failed:', e)
+                    cam = None
             else:
                 log('[INFO] No ToupCam devices detected by EnumV2().')
         except Exception as e:


### PR DESCRIPTION
## Summary
- log warning if camera close fails during diagnostics
- ensure camera resource is released even when close raises

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8fc215e088324a010c5fa5b3153d0