### PR TITLE
Add separate device connection controls and stage info display

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -147,6 +147,33 @@ class StageMarlin:
         self.send("G90", wait_ok=True)
         self.send(" ".join(parts), wait_ok=wait_ok)
 
+    # --------------------------- QUERY ---------------------------
+
+    def get_info(self):
+        resp = self.send("M115")
+        name = None; uuid = None
+        for token in resp.replace("\n", " ").split():
+            if token.startswith("MACHINE_NAME:"):
+                name = token.split(":", 1)[1]
+            elif token.startswith("MACHINE_UUID:"):
+                uuid = token.split(":", 1)[1]
+        return {"name": name, "uuid": uuid, "raw": resp}
+
+    def get_position(self):
+        resp = self.send("M114")
+        x = y = z = None
+        for token in resp.replace("Count", "").split():
+            if token.startswith("X:"):
+                try: x = float(token[2:])
+                except ValueError: pass
+            elif token.startswith("Y:"):
+                try: y = float(token[2:])
+                except ValueError: pass
+            elif token.startswith("Z:"):
+                try: z = float(token[2:])
+                except ValueError: pass
+        return (x, y, z)
+
     def wait_for_moves(self, timeout_s=5.0):
         # M400 blocks until the planner is empty; keep it, but it should run off the UI thread.
         self.send("M400", wait_ok=True)

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -51,6 +51,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.fps_timer = QtCore.QTimer(self)
         self.fps_timer.setInterval(500)             # update FPS label
         self.fps_timer.timeout.connect(self._update_fps)
+        self.pos_timer = QtCore.QTimer(self)
+        self.pos_timer.setInterval(250)
+        self.pos_timer.timeout.connect(self._poll_stage_position)
 
         # UI
         self._build_ui()
@@ -72,13 +75,22 @@ class MainWindow(QtWidgets.QMainWindow):
         leftw = QtWidgets.QWidget()
         left = QtWidgets.QVBoxLayout(leftw)
         self.stage_status = QtWidgets.QLabel("Stage: —")
+        self.stage_pos = QtWidgets.QLabel("Pos: —")
+        self.btn_stage_connect = QtWidgets.QPushButton("Connect Stage")
+        self.btn_stage_disconnect = QtWidgets.QPushButton("Disconnect Stage")
         self.cam_status = QtWidgets.QLabel("Camera: —")
-        self.btn_connect = QtWidgets.QPushButton("Connect Devices")
+        self.btn_cam_connect = QtWidgets.QPushButton("Connect Camera")
+        self.btn_cam_disconnect = QtWidgets.QPushButton("Disconnect Camera")
         self.profile_combo = QtWidgets.QComboBox()
         self.btn_reload_profiles = QtWidgets.QPushButton("Reload Profiles")
         left.addWidget(self.stage_status)
+        left.addWidget(self.stage_pos)
+        left.addWidget(self.btn_stage_connect)
+        left.addWidget(self.btn_stage_disconnect)
+        left.addSpacing(8)
         left.addWidget(self.cam_status)
-        left.addWidget(self.btn_connect)
+        left.addWidget(self.btn_cam_connect)
+        left.addWidget(self.btn_cam_disconnect)
         left.addSpacing(8)
         left.addWidget(QtWidgets.QLabel("Profile:"))
         left.addWidget(self.profile_combo)
@@ -227,9 +239,14 @@ class MainWindow(QtWidgets.QMainWindow):
         root.addWidget(vsplit)
 
         self._reload_profiles()
+        self._update_stage_buttons()
+        self._update_cam_buttons()
 
     def _connect_signals(self):
-        self.btn_connect.clicked.connect(self._auto_connect_async)
+        self.btn_stage_connect.clicked.connect(self._connect_stage_async)
+        self.btn_stage_disconnect.clicked.connect(self._disconnect_stage)
+        self.btn_cam_connect.clicked.connect(self._connect_camera)
+        self.btn_cam_disconnect.clicked.connect(self._disconnect_camera)
         self.btn_capture.clicked.connect(self._capture)
         self.btn_home.clicked.connect(self._home)
         self.btn_xm.clicked.connect(lambda: self._jog(dx=-self.step_spin.value()))
@@ -265,28 +282,62 @@ class MainWindow(QtWidgets.QMainWindow):
     # --------------------------- CONNECT ---------------------------
 
     def _auto_connect_async(self):
-        # CAMERA (quick); don’t reopen if we already have one
-        if self.camera is None:
-            try:
-                cam = create_camera()
-                self.camera = cam
-                self.cam_status.setText(f"Camera: {self.camera.name()}")
-                self.camera.start_stream()
-                self._populate_resolutions()
-                self.preview_timer.start()
-                self.fps_timer.start()
-                log("UI: camera connected")
-            except Exception as e:
-                log(f"UI: camera connect failed: {e}")
-        else:
-            log("UI: camera already connected; skip re-open")
+        self._connect_camera()
+        self._connect_stage_async()
 
-        # If stage already running, don't re-probe
+    def _attach_stage_worker(self):
+        if not self.stage or self.stage_thread:
+            return
+        self.stage_thread = QtCore.QThread(self)
+        self.stage_worker = SerialWorker(self.stage)
+        self.stage_worker.moveToThread(self.stage_thread)
+        self.stage_worker.result.connect(self._dispatch_stage_result)
+        self.stage_thread.started.connect(self.stage_worker.loop)
+        self.stage_thread.start()
+        self.pos_timer.start()
+
+    def _dispatch_stage_result(self, cb, res):
+        if cb:
+            cb(res)
+
+    # --------------------------- CONNECT/DISCONNECT ---------------------------
+
+    def _connect_camera(self):
+        if self.camera is not None:
+            log("UI: camera already connected; skip re-open")
+            return
+        try:
+            cam = create_camera()
+            self.camera = cam
+            self.cam_status.setText(f"Camera: {self.camera.name()}")
+            self.camera.start_stream()
+            self._populate_resolutions()
+            self.preview_timer.start()
+            self.fps_timer.start()
+            log("UI: camera connected")
+        except Exception as e:
+            log(f"UI: camera connect failed: {e}")
+        self._update_cam_buttons()
+
+    def _disconnect_camera(self):
+        if not self.camera:
+            return
+        try:
+            self.camera.stop_stream()
+        except Exception:
+            pass
+        self.camera = None
+        self.cam_status.setText("Camera: —")
+        self.preview_timer.stop()
+        self.fps_timer.stop()
+        self.live_label.clear()
+        self._update_cam_buttons()
+
+    def _connect_stage_async(self):
         if self.stage is not None:
             log("UI: stage already connected; skip re-probe")
             return
 
-        # STAGE async
         def connect_stage():
             port = find_marlin_port()
             if not port:
@@ -296,29 +347,69 @@ class MainWindow(QtWidgets.QMainWindow):
         self._conn_thread, self._conn_worker = run_async(connect_stage)
 
         def _done(stage, err):
-            if err:
-                log(f"UI: stage connect failed: {err}")
+            if err or not stage:
+                if err:
+                    log(f"UI: stage connect failed: {err}")
+                else:
+                    log("UI: stage not found")
                 self.stage_status.setText("Stage: not found")
+                self._update_stage_buttons()
                 return
-            if stage:
-                self.stage = stage
-                self.stage_status.setText("Stage: connected")
-                log("UI: stage connected (async)")
-                self._attach_stage_worker()
-            else:
-                self.stage_status.setText("Stage: not found")
-                log("UI: stage not found")
+            self.stage = stage
+            info = self.stage.get_info()
+            name = info.get("name") or "connected"
+            uuid = info.get("uuid")
+            text = f"Stage: {name}"
+            if uuid:
+                text += f" ({uuid})"
+            self.stage_status.setText(text)
+            log("UI: stage connected (async)")
+            self._attach_stage_worker()
+            self._update_stage_buttons()
 
         self._conn_worker.finished.connect(_done)
 
-    def _attach_stage_worker(self):
-        if not self.stage or self.stage_thread:
+    def _disconnect_stage(self):
+        if self.stage_worker:
+            self.stage_worker.stop()
+        if self.stage_thread:
+            self.stage_thread.quit()
+            self.stage_thread.wait(2000)
+            self.stage_thread = None
+            self.stage_worker = None
+        if self.stage:
+            try:
+                self.stage.ser.close()
+            except Exception:
+                pass
+            self.stage = None
+        self.stage_status.setText("Stage: —")
+        self.stage_pos.setText("Pos: —")
+        self.pos_timer.stop()
+        self._update_stage_buttons()
+
+    def _update_stage_buttons(self):
+        connected = self.stage is not None
+        self.btn_stage_connect.setEnabled(not connected)
+        self.btn_stage_disconnect.setEnabled(connected)
+
+    def _update_cam_buttons(self):
+        connected = self.camera is not None
+        self.btn_cam_connect.setEnabled(not connected)
+        self.btn_cam_disconnect.setEnabled(connected)
+
+    def _poll_stage_position(self):
+        if not self.stage_worker:
             return
-        self.stage_thread = QtCore.QThread(self)
-        self.stage_worker = SerialWorker(self.stage)
-        self.stage_worker.moveToThread(self.stage_thread)
-        self.stage_thread.started.connect(self.stage_worker.loop)
-        self.stage_thread.start()
+        self.stage_worker.enqueue(self.stage.get_position, callback=self._on_stage_position)
+
+    def _on_stage_position(self, pos):
+        if not pos:
+            return
+        x, y, z = pos
+        if x is None or y is None or z is None:
+            return
+        self.stage_pos.setText(f"Pos: X{x:.3f} Y{y:.3f} Z{z:.3f}")
 
     # --------------------------- PREVIEW ---------------------------
 

--- a/microstage_app/utils/serial_worker.py
+++ b/microstage_app/utils/serial_worker.py
@@ -4,6 +4,7 @@ from queue import Queue, Empty
 class SerialWorker(QtCore.QObject):
     finished = QtCore.Signal()
     errored = QtCore.Signal(str)
+    result = QtCore.Signal(object, object)  # callback, result
 
     def __init__(self, stage):
         super().__init__()
@@ -16,18 +17,20 @@ class SerialWorker(QtCore.QObject):
         try:
             while self._running:
                 try:
-                    fn, args, kwargs = self._q.get(timeout=0.1)
+                    fn, args, kwargs, cb = self._q.get(timeout=0.1)
                 except Empty:
                     continue
                 try:
-                    fn(*args, **kwargs)
+                    res = fn(*args, **kwargs)
+                    if cb:
+                        self.result.emit(cb, res)
                 except Exception as e:
                     self.errored.emit(str(e))
         finally:
             self.finished.emit()
 
-    def enqueue(self, fn, *args, **kwargs):
-        self._q.put((fn, args, kwargs))
+    def enqueue(self, fn, *args, callback=None, **kwargs):
+        self._q.put((fn, args, kwargs, callback))
 
     def stop(self):
         self._running = False


### PR DESCRIPTION
## Summary
- Split stage and camera connections into independent connect/disconnect buttons
- Query stage firmware for name/UUID and show live XYZ position in UI
- Allow serial worker tasks to return results via callback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab460fa1548324ae26937a2dd8e80c