### PR TITLE
Add device connection controls and feed rate limit display

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -1,7 +1,7 @@
 import yaml, os
 
 DEFAULTS = {
-    'stage': {'feed_mm_s': 5.0, 'settle_ms': 30},
+    'stage': {'feed_mm_s': 20.0 / 60.0, 'settle_ms': 30},
     'camera': {'exposure_ms': 10.0, 'gain': 1.0, 'binning': 1},
     'scan_presets': {'raster': {'pitch_x_mm': 1.0, 'pitch_y_mm': 1.0, 'rows': 5, 'cols': 5}}
 }

--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -147,6 +147,33 @@ class StageMarlin:
         self.send("G90", wait_ok=True)
         self.send(" ".join(parts), wait_ok=wait_ok)
 
+    # --------------------------- QUERY ---------------------------
+
+    def get_info(self):
+        resp = self.send("M115")
+        name = None; uuid = None
+        for token in resp.replace("\n", " ").split():
+            if token.startswith("MACHINE_NAME:"):
+                name = token.split(":", 1)[1]
+            elif token.startswith("MACHINE_UUID:"):
+                uuid = token.split(":", 1)[1]
+        return {"name": name, "uuid": uuid, "raw": resp}
+
+    def get_position(self):
+        resp = self.send("M114")
+        x = y = z = None
+        for token in resp.replace("Count", "").split():
+            if token.startswith("X:"):
+                try: x = float(token[2:])
+                except ValueError: pass
+            elif token.startswith("Y:"):
+                try: y = float(token[2:])
+                except ValueError: pass
+            elif token.startswith("Z:"):
+                try: z = float(token[2:])
+                except ValueError: pass
+        return (x, y, z)
+
     def wait_for_moves(self, timeout_s=5.0):
         # M400 blocks until the planner is empty; keep it, but it should run off the UI thread.
         self.send("M400", wait_ok=True)

--- a/microstage_app/utils/serial_worker.py
+++ b/microstage_app/utils/serial_worker.py
@@ -4,6 +4,7 @@ from queue import Queue, Empty
 class SerialWorker(QtCore.QObject):
     finished = QtCore.Signal()
     errored = QtCore.Signal(str)
+    result = QtCore.Signal(object, object)  # callback, result
 
     def __init__(self, stage):
         super().__init__()
@@ -16,18 +17,20 @@ class SerialWorker(QtCore.QObject):
         try:
             while self._running:
                 try:
-                    fn, args, kwargs = self._q.get(timeout=0.1)
+                    fn, args, kwargs, cb = self._q.get(timeout=0.1)
                 except Empty:
                     continue
                 try:
-                    fn(*args, **kwargs)
+                    res = fn(*args, **kwargs)
+                    if cb:
+                        self.result.emit(cb, res)
                 except Exception as e:
                     self.errored.emit(str(e))
         finally:
             self.finished.emit()
 
-    def enqueue(self, fn, *args, **kwargs):
-        self._q.put((fn, args, kwargs))
+    def enqueue(self, fn, *args, callback=None, **kwargs):
+        self._q.put((fn, args, kwargs, callback))
 
     def stop(self):
         self._running = False


### PR DESCRIPTION
## Summary
- Split stage and camera connections into independent connect/disconnect buttons
- Query stage firmware for name/UUID and show live XYZ position in UI
- Allow serial worker tasks to return results via callback
- Display feed rate limits from Configuration.h and lower default feed to 20 mm/min

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab460fa1548324ae26937a2dd8e80c