### PR TITLE
Handle async threads during stage connect/disconnect

### DIFF
--- a/microstage_app/utils/workers.py
+++ b/microstage_app/utils/workers.py
@@ -19,5 +19,8 @@ def run_async(fn, *args, **kwargs):
     worker = FuncWorker(fn, *args, **kwargs)
     worker.moveToThread(thread)
     thread.started.connect(worker.run)
+    worker.finished.connect(thread.quit)
+    thread.finished.connect(worker.deleteLater)
+    thread.finished.connect(thread.deleteLater)
     thread.start()
     return thread, worker


### PR DESCRIPTION
## Summary
- Stop FuncWorker threads by quitting their QThread after completion
- Clean up stage connection threads when connection finishes or stage disconnects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab939bd67c8324be35cd7cca4aa735