### PR TITLE
Handle new M115 MACHINE_TYPE/UUID tokens

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -153,11 +153,12 @@ class StageMarlin:
 
     def get_info(self):
         resp = self.send("M115")
-        name = None; uuid = None
+        name = None
+        uuid = None
         for token in resp.replace("\n", " ").split():
-            if token.startswith("MACHINE_NAME:"):
+            if token.startswith("MACHINE_TYPE:") or token.startswith("MACHINE_NAME:"):
                 name = token.split(":", 1)[1]
-            elif token.startswith("MACHINE_UUID:"):
+            elif token.startswith("UUID:") or token.startswith("MACHINE_UUID:"):
                 uuid = token.split(":", 1)[1]
         return {"name": name, "uuid": uuid, "raw": resp}
 

--- a/microstage_app/tests/test_stage_info.py
+++ b/microstage_app/tests/test_stage_info.py
@@ -1,0 +1,14 @@
+from microstage_app.devices.stage_marlin import StageMarlin
+
+
+def test_get_info_parses_new_tokens():
+    response = (
+        "FIRMWARE_NAME:Marlin MACHINE_TYPE:MicroStageController "
+        "UUID:a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n"
+    )
+    s = StageMarlin.__new__(StageMarlin)
+    s.send = lambda cmd, wait_ok=True: response
+    info = StageMarlin.get_info(s)
+    assert info["name"] == "MicroStageController"
+    assert info["uuid"] == "a3a4637a-68c4-4340-9fda-847b4fe0d3fc"
+

--- a/microstage_app/tests/test_stage_probe.py
+++ b/microstage_app/tests/test_stage_probe.py
@@ -34,7 +34,7 @@ def test_identifiers_match(monkeypatch):
 
         def read(self, n):
             return (
-                b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n"
+                b"FIRMWARE_NAME:Marlin MACHINE_TYPE:MicroStageController UUID:a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n"
             )
 
     monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [Port()])
@@ -69,7 +69,7 @@ def test_machine_name_mismatch(monkeypatch):
             pass
 
         def read(self, n):
-            return b"FIRMWARE_NAME:Marlin MACHINE_NAME:Other UUID:0000\nok\n"
+            return b"FIRMWARE_NAME:Marlin MACHINE_TYPE:Other UUID:0000\nok\n"
 
     monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [Port()])
     monkeypatch.setattr(stage_marlin.serial, "Serial", DummySerial)
@@ -104,7 +104,7 @@ def test_uuid_mismatch_still_accepts(monkeypatch):
             pass
 
         def read(self, n):
-            return b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:0000\nok\n"
+            return b"FIRMWARE_NAME:Marlin MACHINE_TYPE:MicroStageController UUID:0000\nok\n"
 
     monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [Port()])
     monkeypatch.setattr(stage_marlin.serial, "Serial", DummySerial)
@@ -127,8 +127,8 @@ def test_prefers_uuid_when_multiple(monkeypatch):
         pid = 0x7523
 
     responses = {
-        "COMA": b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:0000\nok\n",
-        "COMB": b"FIRMWARE_NAME:Marlin MACHINE_NAME:MicroStageController UUID:a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n",
+        "COMA": b"FIRMWARE_NAME:Marlin MACHINE_TYPE:MicroStageController UUID:0000\nok\n",
+        "COMB": b"FIRMWARE_NAME:Marlin MACHINE_TYPE:MicroStageController UUID:a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n",
     }
 
     class DummySerial:


### PR DESCRIPTION
## Summary
- parse both legacy MACHINE_NAME/MACHINE_UUID and new MACHINE_TYPE/UUID tokens in StageMarlin.get_info
- add unit test for parsing new tokens
- update probe tests to use MACHINE_TYPE and UUID identifiers

## Testing
- `pytest microstage_app/tests/test_stage_info.py microstage_app/tests/test_stage_probe.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab96eda2308324857d5f85d1c67632