### PR TITLE
Handle stage connect on GUI thread

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -468,39 +468,38 @@ class MainWindow(QtWidgets.QMainWindow):
             return StageMarlin(port)
 
         self._conn_thread, self._conn_worker = run_async(connect_stage)
+        self._conn_worker.finished.connect(self._on_stage_connect)
 
-        def _done(stage, err):
-            if err or not stage:
-                if err:
-                    log(f"UI: stage connect failed: {err}")
-                else:
-                    log("UI: stage not found")
-                self.stage_status.setText("Stage: not found")
-                self._update_stage_buttons()
+    @QtCore.Slot(object, object)
+    def _on_stage_connect(self, stage, err):
+        if err or not stage:
+            if err:
+                log(f"UI: stage connect failed: {err}")
             else:
-                self.stage = stage
-                info = self.stage.get_info()
-                name = info.get("name") or "connected"
-                uuid = info.get("uuid")
-                text = f"Stage: {name}"
-                if uuid:
-                    text += f" ({uuid})"
-                self.stage_status.setText(text)
-                try:
-                    self.stage_bounds = self.stage.get_bounds()
-                except Exception as e:
-                    log(f"Stage: failed to get bounds: {e}")
-                    self.stage_bounds = None
-                log("UI: stage connected (async)")
-                self._attach_stage_worker()
-                self._update_stage_buttons()
-            thread = self._conn_thread
-            self._conn_thread = None
-            self._conn_worker = None
-            if thread:
-                thread.wait()
-
-        self._conn_worker.finished.connect(_done)
+                log("UI: stage not found")
+            self.stage_status.setText("Stage: not found")
+            self._update_stage_buttons()
+        else:
+            self.stage = stage
+            info = self.stage.get_info()
+            name = info.get("name") or "connected"
+            uuid = info.get("uuid")
+            text = f"Stage: {name}"
+            if uuid:
+                text += f" ({uuid})"
+            self.stage_status.setText(text)
+            try:
+                self.stage_bounds = self.stage.get_bounds()
+            except Exception as e:
+                log(f"Stage: failed to get bounds: {e}")
+                self.stage_bounds = None
+            log("UI: stage connected (async)")
+            self._attach_stage_worker()
+            self._update_stage_buttons()
+        thread = self._conn_thread
+        self._conn_thread = self._conn_worker = None
+        if thread and thread != QtCore.QThread.currentThread():
+            thread.wait()
 
     def _disconnect_stage(self):
         if self._conn_thread:


### PR DESCRIPTION
## Summary
- Replace local `_done` callback with `_on_stage_connect` slot on `MainWindow`
- Connect async worker `finished` signal to new slot and clean up thread safely
- Ensure stage worker attachment and UI updates run on the GUI thread

## Testing
- `pytest microstage_app/tests`

------
https://chatgpt.com/codex/tasks/task_e_68ac1d77c4148324a14eaff8cbec7141