### PR TITLE
Ignore 'Count' values when parsing stage position

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -193,8 +193,9 @@ class StageMarlin:
 
     def get_position(self):
         resp = self.send("M114")
+        before_count = resp.split("Count", 1)[0]
         x = y = z = None
-        for token in resp.replace("Count", "").split():
+        for token in before_count.split():
             if token.startswith("X:"):
                 try: x = float(token[2:])
                 except ValueError: pass


### PR DESCRIPTION
## Summary
- Adjust Marlin stage position parsing to tokenize response only before the `Count` section

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac26c415dc832497c495a2097091ec