### PR TITLE
Reset input buffer before sending G-code commands

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -99,11 +99,12 @@ class StageMarlin:
             pass
 
     def _send_log(self, cmd):
-        line = (cmd.strip() + "\n").encode()
-        log(f"TX >> {cmd}")
-        self.ser.write(line)
+        line = cmd.strip()
+        log(f"TX >> {line}")
+        self._write(line)
 
     def _write(self, cmd):
+        self.ser.reset_input_buffer()
         self.ser.write((cmd.strip() + '\n').encode())
 
     def _read_until_ok(self):


### PR DESCRIPTION
## Summary
- clear the serial input buffer before writing each command to the Marlin stage
- log and write commands through a unified helper that performs the reset

## Testing
- `pytest microstage_app/tests/test_stage_driver.py microstage_app/tests/test_stage_info.py microstage_app/tests/test_stage_probe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac278e46448324a2bf27a8a37c7638