### PR TITLE
Defer camera streaming until start

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -232,19 +232,7 @@ class ToupcamCamera:
                 log(f"Camera: PullImage error: {e}")
 
         self._on_event = _on_event
-        try:
-            self._cam.StartPullModeWithCallback(self._on_event, self)
-        except TypeError:
-            self._cam.StartPullModeWithCallback(self._on_event)
-        log("Camera: pull mode started")
-
-        # Sensible defaults
-        try:
-            self._cam.put_AutoExpoEnable(0)
-        except Exception:
-            pass
-
-        self._is_streaming = True
+        # Stream startup is deferred to start_stream()
 
     # ---------------- public API used by UI ----------------
 
@@ -254,7 +242,6 @@ class ToupcamCamera:
     def start_stream(self):
         if self._cam is None:
             self._open()
-            return
 
         if self._is_streaming:
             return

--- a/microstage_app/tests/test_resolution_combo.py
+++ b/microstage_app/tests/test_resolution_combo.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+import microstage_app.ui.main_window as mw
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_res_combo_lists_and_updates(monkeypatch, qt_app):
+    class FakeCamera:
+        def __init__(self):
+            self.resolutions = [
+                (0, 1920, 1080),
+                (1, 1280, 720),
+                (2, 640, 480),
+            ]
+            self.current_idx = 0
+
+        def name(self):
+            return "FakeCam"
+
+        def start_stream(self):
+            pass
+
+        def list_resolutions(self):
+            return self.resolutions
+
+        def set_resolution_index(self, idx):
+            self.current_idx = idx
+
+    fake = FakeCamera()
+    monkeypatch.setattr(mw, "create_camera", lambda: fake)
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    win = mw.MainWindow()
+    win._connect_camera()
+
+    items = [win.res_combo.itemText(i) for i in range(win.res_combo.count())]
+    assert items == [f"{w}×{h}" for _, w, h in fake.resolutions]
+
+    win.res_combo.setCurrentIndex(2)
+    win._apply_resolution(2)
+    assert fake.current_idx == 2
+
+    win.preview_timer.stop()
+    win.fps_timer.stop()
+    win.close()

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -428,8 +428,8 @@ class MainWindow(QtWidgets.QMainWindow):
             cam = create_camera()
             self.camera = cam
             self.cam_status.setText(f"Camera: {self.camera.name()}")
-            self.camera.start_stream()
             self._populate_resolutions()
+            self.camera.start_stream()
             self._sync_cam_controls()
             self.preview_timer.start()
             self.fps_timer.start()


### PR DESCRIPTION
## Summary
- open Toupcam devices without immediately starting streaming, moving `StartPullModeWithCallback` to `start_stream`
- populate resolution combo before streaming so available sizes are listed
- add regression test ensuring resolution combo population and selection updates camera resolution

## Testing
- `QT_QPA_PLATFORM=offscreen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2b25d18c8324a96dcfe601bfd1d8