### PR TITLE
Align camera sliders with spin boxes

### DIFF
--- a/microstage_app/tests/test_slider_spin_sync.py
+++ b/microstage_app/tests/test_slider_spin_sync.py
@@ -1,0 +1,67 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+import microstage_app.ui.main_window as mw
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_slider_spin_alignment_and_sync(monkeypatch, qt_app):
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    win = mw.MainWindow()
+
+    pairs = [
+        (win.brightness_slider, win.brightness_spin),
+        (win.contrast_slider, win.contrast_spin),
+        (win.saturation_slider, win.saturation_spin),
+        (win.hue_slider, win.hue_spin),
+        (win.gamma_slider, win.gamma_spin),
+    ]
+
+    for slider, spin in pairs:
+        assert slider.value() == spin.value()
+
+    win.brightness_slider.setValue(10)
+    qt_app.processEvents()
+    assert win.brightness_spin.value() == 10
+
+    win.contrast_spin.setValue(20)
+    qt_app.processEvents()
+    assert win.contrast_slider.value() == 20
+
+    class FakeCam:
+        def get_brightness(self):
+            return 5
+
+        def get_contrast(self):
+            return 6
+
+        def get_saturation(self):
+            return 7
+
+        def get_hue(self):
+            return 8
+
+        def get_gamma(self):
+            return 60
+
+    win.camera = FakeCam()
+    win._sync_cam_controls()
+
+    expected = [5, 6, 7, 8, 60]
+    for (slider, spin), val in zip(pairs, expected):
+        assert slider.value() == val
+        assert spin.value() == val
+
+    win.preview_timer.stop()
+    win.fps_timer.stop()
+    win.close()
+

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -215,22 +215,27 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.brightness_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal); self.brightness_slider.setRange(-255, 255)
         self.brightness_spin = QtWidgets.QSpinBox(); self.brightness_spin.setRange(-255, 255); self.brightness_spin.setValue(0)
+        self.brightness_slider.setValue(self.brightness_spin.value())
         c.addWidget(QtWidgets.QLabel("Brightness:"), row, 0); c.addWidget(self.brightness_slider, row, 1); c.addWidget(self.brightness_spin, row, 2); row += 1
 
         self.contrast_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal); self.contrast_slider.setRange(-255, 255)
         self.contrast_spin = QtWidgets.QSpinBox(); self.contrast_spin.setRange(-255, 255); self.contrast_spin.setValue(0)
+        self.contrast_slider.setValue(self.contrast_spin.value())
         c.addWidget(QtWidgets.QLabel("Contrast:"), row, 0); c.addWidget(self.contrast_slider, row, 1); c.addWidget(self.contrast_spin, row, 2); row += 1
 
         self.saturation_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal); self.saturation_slider.setRange(0, 255)
         self.saturation_spin = QtWidgets.QSpinBox(); self.saturation_spin.setRange(0, 255); self.saturation_spin.setValue(128)
+        self.saturation_slider.setValue(self.saturation_spin.value())
         c.addWidget(QtWidgets.QLabel("Saturation:"), row, 0); c.addWidget(self.saturation_slider, row, 1); c.addWidget(self.saturation_spin, row, 2); row += 1
 
         self.hue_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal); self.hue_slider.setRange(-180, 180)
         self.hue_spin = QtWidgets.QSpinBox(); self.hue_spin.setRange(-180, 180); self.hue_spin.setValue(0)
+        self.hue_slider.setValue(self.hue_spin.value())
         c.addWidget(QtWidgets.QLabel("Hue:"), row, 0); c.addWidget(self.hue_slider, row, 1); c.addWidget(self.hue_spin, row, 2); row += 1
 
         self.gamma_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal); self.gamma_slider.setRange(20, 180)
         self.gamma_spin = QtWidgets.QSpinBox(); self.gamma_spin.setRange(20, 180); self.gamma_spin.setValue(100)
+        self.gamma_slider.setValue(self.gamma_spin.value())
         c.addWidget(QtWidgets.QLabel("Gamma:"), row, 0); c.addWidget(self.gamma_slider, row, 1); c.addWidget(self.gamma_spin, row, 2); row += 1
 
         self.raw_chk = QtWidgets.QCheckBox("RAW8 fast mono (triples bandwidth efficiency)")
@@ -600,27 +605,37 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         try:
             if hasattr(self.camera, "get_brightness"):
-                self.brightness_spin.setValue(int(self.camera.get_brightness()))
+                val = int(self.camera.get_brightness())
+                self.brightness_spin.setValue(val)
+                self.brightness_slider.setValue(val)
         except Exception:
             pass
         try:
             if hasattr(self.camera, "get_contrast"):
-                self.contrast_spin.setValue(int(self.camera.get_contrast()))
+                val = int(self.camera.get_contrast())
+                self.contrast_spin.setValue(val)
+                self.contrast_slider.setValue(val)
         except Exception:
             pass
         try:
             if hasattr(self.camera, "get_saturation"):
-                self.saturation_spin.setValue(int(self.camera.get_saturation()))
+                val = int(self.camera.get_saturation())
+                self.saturation_spin.setValue(val)
+                self.saturation_slider.setValue(val)
         except Exception:
             pass
         try:
             if hasattr(self.camera, "get_hue"):
-                self.hue_spin.setValue(int(self.camera.get_hue()))
+                val = int(self.camera.get_hue())
+                self.hue_spin.setValue(val)
+                self.hue_slider.setValue(val)
         except Exception:
             pass
         try:
             if hasattr(self.camera, "get_gamma"):
-                self.gamma_spin.setValue(int(self.camera.get_gamma()))
+                val = int(self.camera.get_gamma())
+                self.gamma_spin.setValue(val)
+                self.gamma_slider.setValue(val)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- Initialize camera setting sliders to spin box values so controls start aligned
- Sync sliders with camera state in `_sync_cam_controls`
- Add test verifying slider-spin synchronization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c9106e88324ba0fc035e9529df4