### PR TITLE
Add mock camera resolution list and UI fallback tests

### DIFF
--- a/microstage_app/devices/camera_mock.py
+++ b/microstage_app/devices/camera_mock.py
@@ -6,6 +6,7 @@ class MockCamera:
         self._running = False
         self._latest = None
         self._t = 0.0
+        self._resolution_idx = 0
 
     def name(self): return "MockCamera"
     def start_stream(self): self._running = True
@@ -22,3 +23,15 @@ class MockCamera:
 
     def snap(self):
         return self.get_latest_frame()
+
+    # Mock resolution handling -------------------------------------------------
+
+    def list_resolutions(self):
+        """Return a small list of fake resolution tuples."""
+        return [
+            (0, 640, 480),
+            (1, 320, 240),
+        ]
+
+    def set_resolution_index(self, idx):
+        self._resolution_idx = int(idx)

--- a/microstage_app/tests/test_ui_mock_camera_connect.py
+++ b/microstage_app/tests/test_ui_mock_camera_connect.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+import microstage_app.ui.main_window as mw
+from microstage_app.devices.camera_mock import MockCamera
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_ui_connects_with_mock_camera(monkeypatch, qt_app):
+    monkeypatch.setattr(mw, "create_camera", lambda: MockCamera())
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    win = mw.MainWindow()
+    win._connect_camera()
+
+    assert win.camera is not None
+    items = [win.res_combo.itemText(i) for i in range(win.res_combo.count())]
+    assert items == ["640×480", "320×240"]
+
+    win.preview_timer.stop()
+    win.fps_timer.stop()
+    win.close()


### PR DESCRIPTION
## Summary
- implement `list_resolutions` and simple `set_resolution_index` in mock camera
- add UI test ensuring connection works with mock camera and populates resolutions

## Testing
- `pytest microstage_app/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2dbbceb48324b3373f5105fb1ee0