### PR TITLE
Handle spaces in stage info parsing and display machine type

### DIFF
--- a/microstage_app/tests/test_stage_info.py
+++ b/microstage_app/tests/test_stage_info.py
@@ -9,6 +9,18 @@ def test_get_info_parses_new_tokens():
     s = StageMarlin.__new__(StageMarlin)
     s.send = lambda cmd, wait_ok=True: response
     info = StageMarlin.get_info(s)
-    assert info["name"] == "MicroStageController"
+    assert info["machine_type"] == "MicroStageController"
+    assert info["uuid"] == "a3a4637a-68c4-4340-9fda-847b4fe0d3fc"
+
+
+def test_get_info_handles_spaces_after_colon():
+    response = (
+        "FIRMWARE_NAME:Marlin MACHINE_TYPE: MicroStageController "
+        "UUID: a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n"
+    )
+    s = StageMarlin.__new__(StageMarlin)
+    s.send = lambda cmd, wait_ok=True: response
+    info = StageMarlin.get_info(s)
+    assert info["machine_type"] == "MicroStageController"
     assert info["uuid"] == "a3a4637a-68c4-4340-9fda-847b4fe0d3fc"
 

--- a/microstage_app/tests/test_stage_probe.py
+++ b/microstage_app/tests/test_stage_probe.py
@@ -44,6 +44,42 @@ def test_identifiers_match(monkeypatch):
     assert find_marlin_port() == "COMX"
 
 
+def test_identifiers_match_with_spaces(monkeypatch):
+    from microstage_app.devices import stage_marlin
+
+    class Port:
+        device = "COMS"
+        vid = 0x1A86
+        pid = 0x7523
+
+    class DummySerial:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, data):
+            pass
+
+        def read(self, n):
+            return (
+                b"FIRMWARE_NAME:Marlin MACHINE_TYPE: MicroStageController UUID: a3a4637a-68c4-4340-9fda-847b4fe0d3fc\nok\n"
+            )
+
+    monkeypatch.setattr(stage_marlin.list_ports, "comports", lambda: [Port()])
+    monkeypatch.setattr(stage_marlin.serial, "Serial", DummySerial)
+    monkeypatch.setattr(stage_marlin.time, "sleep", lambda x: None)
+
+    assert find_marlin_port() == "COMS"
+
+
 def test_machine_name_mismatch(monkeypatch):
     from microstage_app.devices import stage_marlin
 

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -483,7 +483,7 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             self.stage = stage
             info = self.stage.get_info()
-            name = info.get("name") or "connected"
+            name = info.get("machine_type") or info.get("name") or "connected"
             uuid = info.get("uuid")
             text = f"Stage: {name}"
             if uuid:


### PR DESCRIPTION
## Summary
- Parse `M115` responses using regex so `MACHINE_TYPE`, optional `MACHINE_NAME`, and `UUID` values handle leading spaces
- Show machine type (or name) with UUID in the stage status text
- Add tests covering `M115` responses with spaces after colons

## Testing
- `pytest microstage_app/tests/test_stage_info.py microstage_app/tests/test_stage_probe.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac310e59308324b0b9df8066ccf189