### PR TITLE
Select mock frame resolution

### DIFF
--- a/microstage_app/devices/camera_mock.py
+++ b/microstage_app/devices/camera_mock.py
@@ -13,10 +13,16 @@ class MockCamera:
     def stop_stream(self): self._running = False
 
     def get_latest_frame(self):
-        h, w = 480, 640
+        """Generate a grayscale gradient image at the selected resolution."""
+        try:
+            _, w, h = self.list_resolutions()[self._resolution_idx]
+        except Exception:
+            # Fall back to the first resolution if index is invalid
+            _, w, h = self.list_resolutions()[0]
+
         x = np.linspace(0, 1, w, dtype=np.float32)
         y = np.linspace(0, 1, h, dtype=np.float32)[:, None]
-        img = (x + y + 0.2*np.sin(10*(x+y+self._t))) % 1.0
+        img = (x + y + 0.2 * np.sin(10 * (x + y + self._t))) % 1.0
         self._t += 0.05
         rgb = np.dstack([img, img, img])
         return (np.clip(rgb, 0, 1) * 255).astype(np.uint8)


### PR DESCRIPTION
## Summary
- Use the selected resolution index in `MockCamera.get_latest_frame`
- Generate mock frames at the chosen width and height

## Testing
- `pytest microstage_app/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac36118b3c832489ffdff9f85912a6