### PR TITLE
Sync resolution combo with camera

### DIFF
--- a/microstage_app/devices/camera_mock.py
+++ b/microstage_app/devices/camera_mock.py
@@ -35,3 +35,6 @@ class MockCamera:
 
     def set_resolution_index(self, idx):
         self._resolution_idx = int(idx)
+
+    def get_resolution_index(self):
+        return int(self._resolution_idx)

--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -319,6 +319,19 @@ class ToupcamCamera:
             out.append((0, self._w, self._h))
         return out
 
+    def get_resolution_index(self) -> int:
+        """Return current resolution index if available."""
+        try:
+            return int(self._cam.get_eSize())
+        except Exception:
+            try:
+                for idx, w, h in self.list_resolutions():
+                    if w == self._w and h == self._h:
+                        return int(idx)
+            except Exception:
+                pass
+            return 0
+
     def set_resolution_index(self, idx: int):
         try:
             self._cam.put_eSize(int(idx))

--- a/microstage_app/tests/test_resolution_combo.py
+++ b/microstage_app/tests/test_resolution_combo.py
@@ -21,7 +21,7 @@ def test_res_combo_lists_and_updates(monkeypatch, qt_app):
                 (1, 1280, 720),
                 (2, 640, 480),
             ]
-            self.current_idx = 0
+            self.current_idx = 1
 
         def name(self):
             return "FakeCam"
@@ -35,6 +35,9 @@ def test_res_combo_lists_and_updates(monkeypatch, qt_app):
         def set_resolution_index(self, idx):
             self.current_idx = idx
 
+        def get_resolution_index(self):
+            return self.current_idx
+
     fake = FakeCamera()
     monkeypatch.setattr(mw, "create_camera", lambda: fake)
     monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
@@ -44,6 +47,7 @@ def test_res_combo_lists_and_updates(monkeypatch, qt_app):
 
     items = [win.res_combo.itemText(i) for i in range(win.res_combo.count())]
     assert items == [f"{w}×{h}" for _, w, h in fake.resolutions]
+    assert win.res_combo.currentIndex() == fake.current_idx
 
     win.res_combo.setCurrentIndex(2)
     win._apply_resolution(2)

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -596,8 +596,17 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         self.res_combo.blockSignals(True)
         self.res_combo.clear()
+        current = 0
+        try:
+            if hasattr(self.camera, "get_resolution_index"):
+                current = int(self.camera.get_resolution_index())
+        except Exception:
+            current = 0
         for idx, w, h in self.camera.list_resolutions():
             self.res_combo.addItem(f"{w}×{h}", idx)
+        pos = self.res_combo.findData(current)
+        if pos >= 0:
+            self.res_combo.setCurrentIndex(pos)
         self.res_combo.blockSignals(False)
 
     def _sync_cam_controls(self):


### PR DESCRIPTION
## Summary
- Populate resolution combo with current camera setting by selecting active resolution index.
- Add `get_resolution_index` for both Toupcam and mock cameras.
- Test that combo box starts with the camera's active resolution.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3614ddc88324a6c4151d2b8fdf3b