### PR TITLE
Populate camera resolutions after stream start

### DIFF
--- a/microstage_app/tests/test_resolution_combo.py
+++ b/microstage_app/tests/test_resolution_combo.py
@@ -16,21 +16,24 @@ def qt_app():
 def test_res_combo_lists_and_updates(monkeypatch, qt_app):
     class FakeCamera:
         def __init__(self):
-            self.resolutions = [
+            self.resolutions_after = [
                 (0, 1920, 1080),
                 (1, 1280, 720),
                 (2, 640, 480),
             ]
             self.current_idx = 0
+            self.started = False
 
         def name(self):
             return "FakeCam"
 
         def start_stream(self):
-            pass
+            self.started = True
 
         def list_resolutions(self):
-            return self.resolutions
+            if self.started:
+                return self.resolutions_after
+            return []
 
         def set_resolution_index(self, idx):
             self.current_idx = idx
@@ -43,11 +46,50 @@ def test_res_combo_lists_and_updates(monkeypatch, qt_app):
     win._connect_camera()
 
     items = [win.res_combo.itemText(i) for i in range(win.res_combo.count())]
-    assert items == [f"{w}×{h}" for _, w, h in fake.resolutions]
+    assert items == [f"{w}×{h}" for _, w, h in fake.resolutions_after]
 
     win.res_combo.setCurrentIndex(2)
     win._apply_resolution(2)
     assert fake.current_idx == 2
+
+    win.preview_timer.stop()
+    win.fps_timer.stop()
+    win.close()
+
+
+def test_res_combo_repopulates_on_reconnect(monkeypatch, qt_app):
+    class FakeCamera:
+        def __init__(self, resolutions):
+            self.resolutions = resolutions
+            self.started = False
+
+        def name(self):
+            return "FakeCam"
+
+        def start_stream(self):
+            self.started = True
+
+        def list_resolutions(self):
+            return self.resolutions if self.started else []
+
+        def set_resolution_index(self, idx):
+            pass
+
+    cam1 = FakeCamera([(0, 800, 600)])
+    cam2 = FakeCamera([(0, 1024, 768), (1, 800, 600)])
+    cams = iter([cam1, cam2])
+    monkeypatch.setattr(mw, "create_camera", lambda: next(cams))
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    win = mw.MainWindow()
+    win._connect_camera()
+    items1 = [win.res_combo.itemText(i) for i in range(win.res_combo.count())]
+    assert items1 == [f"{w}×{h}" for _, w, h in cam1.resolutions]
+
+    win._disconnect_camera()
+    win._connect_camera()
+    items2 = [win.res_combo.itemText(i) for i in range(win.res_combo.count())]
+    assert items2 == [f"{w}×{h}" for _, w, h in cam2.resolutions]
 
     win.preview_timer.stop()
     win.fps_timer.stop()

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -433,8 +433,10 @@ class MainWindow(QtWidgets.QMainWindow):
             cam = create_camera()
             self.camera = cam
             self.cam_status.setText(f"Camera: {self.camera.name()}")
-            self._populate_resolutions()
             self.camera.start_stream()
+            # populate after stream start so all resolutions are available
+            self._populate_resolutions()
+            QtCore.QTimer.singleShot(0, self._populate_resolutions)
             self._sync_cam_controls()
             self.preview_timer.start()
             self.fps_timer.start()
@@ -455,6 +457,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.preview_timer.stop()
         self.fps_timer.stop()
         self.live_label.clear()
+        self.res_combo.clear()
         self._update_cam_buttons()
 
     def _connect_stage_async(self):


### PR DESCRIPTION
## Summary
- Populate camera resolution list after the stream is running and refresh once streaming begins
- Clear resolution combo on disconnect so reconnect repopulates
- Test resolution combo after stream start and after reconnect

## Testing
- `python -m pytest microstage_app/tests/test_resolution_combo.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac360ec1b88324860f6e2d7e620cf8