### PR TITLE
Display stage UUID below machine type

### DIFF
--- a/microstage_app/tests/test_ui_stage_status_uuid.py
+++ b/microstage_app/tests/test_ui_stage_status_uuid.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+import microstage_app.ui.main_window as mw
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_stage_status_multiline(monkeypatch, qt_app):
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_attach_stage_worker", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_update_stage_buttons", lambda self: None)
+
+    win = mw.MainWindow()
+
+    class DummyStage:
+        def get_info(self):
+            return {"machine_type": "MicroStageController", "uuid": "1234-uuid"}
+        def get_bounds(self):
+            return {}
+
+    win._on_stage_connect(DummyStage(), None)
+    assert win.stage_status.text() == "Stage: MicroStageController\n1234-uuid"
+
+    win.preview_timer.stop()
+    win.fps_timer.stop()
+    win.close()

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -117,6 +117,7 @@ class MainWindow(QtWidgets.QMainWindow):
         leftw = QtWidgets.QWidget()
         left = QtWidgets.QVBoxLayout(leftw)
         self.stage_status = QtWidgets.QLabel("Stage: —")
+        self.stage_status.setTextFormat(QtCore.Qt.PlainText)
         self.stage_pos = QtWidgets.QLabel("Pos: —")
         self.btn_stage_connect = QtWidgets.QPushButton("Connect Stage")
         self.btn_stage_disconnect = QtWidgets.QPushButton("Disconnect Stage")
@@ -490,7 +491,7 @@ class MainWindow(QtWidgets.QMainWindow):
             uuid = info.get("uuid")
             text = f"Stage: {name}"
             if uuid:
-                text += f" ({uuid})"
+                text += f"\n{uuid}"
             self.stage_status.setText(text)
             try:
                 self.stage_bounds = self.stage.get_bounds()


### PR DESCRIPTION
## Summary
- Allow stage status label to render plain text with newlines
- Show the stage's UUID on a new line when connecting
- Add UI test verifying the UUID appears beneath the machine type

## Testing
- `pytest microstage_app/tests/test_ui_stage_status_uuid.py microstage_app/tests/test_ui_mock_camera_connect.py -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac39dc542c8324b2d23d1f6486986e