### PR TITLE
Add camera exposure/gain getters and auto-update UI controls

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -457,6 +457,20 @@ class ToupcamCamera:
         except Exception as e:
             log(f"Camera: set_gain failed: {e}")
 
+    def get_exposure_ms(self) -> float:
+        try:
+            return float(self._cam.get_ExpoTime()) / 1000.0
+        except Exception as e:
+            log(f"Camera: get_exposure_ms failed: {e}")
+            return 0.0
+
+    def get_gain(self) -> int:
+        try:
+            return int(self._cam.get_ExpoAGain())
+        except Exception as e:
+            log(f"Camera: get_gain failed: {e}")
+            return 0
+
     # ---- image controls ----
 
     def get_brightness(self) -> int:

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -579,11 +579,24 @@ class MainWindow(QtWidgets.QMainWindow):
         if not self.camera:
             return
         frame = self.camera.get_latest_frame()
-        if frame is None:
-            return
-        qimg = numpy_to_qimage(frame)
-        self.live_label.setPixmap(QtGui.QPixmap.fromImage(qimg).scaled(
-            self.live_label.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation))
+        if frame is not None:
+            qimg = numpy_to_qimage(frame)
+            self.live_label.setPixmap(QtGui.QPixmap.fromImage(qimg).scaled(
+                self.live_label.size(), QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation))
+
+        if self.autoexp_chk.isChecked():
+            try:
+                self.exp_spin.blockSignals(True)
+                self.gain_spin.blockSignals(True)
+                ms = float(self.camera.get_exposure_ms())
+                gain = int(self.camera.get_gain())
+                self.exp_spin.setValue(ms)
+                self.gain_spin.setValue(gain)
+            except Exception:
+                pass
+            finally:
+                self.exp_spin.blockSignals(False)
+                self.gain_spin.blockSignals(False)
 
     def _update_fps(self):
         if self.camera:
@@ -656,6 +669,21 @@ class MainWindow(QtWidgets.QMainWindow):
         auto = self.autoexp_chk.isChecked()
         ms = self.exp_spin.value()
         self.camera.set_exposure_ms(ms, auto)
+        self.exp_spin.setEnabled(not auto)
+        self.gain_spin.setEnabled(not auto)
+        if auto:
+            try:
+                self.exp_spin.blockSignals(True)
+                self.gain_spin.blockSignals(True)
+                ms = float(self.camera.get_exposure_ms())
+                gain = int(self.camera.get_gain())
+                self.exp_spin.setValue(ms)
+                self.gain_spin.setValue(gain)
+            except Exception:
+                pass
+            finally:
+                self.exp_spin.blockSignals(False)
+                self.gain_spin.blockSignals(False)
 
     def _apply_gain(self):
         if not self.camera: return


### PR DESCRIPTION
## Summary
- add getters for exposure time and gain in Toupcam camera wrapper
- disable/enable exposure & gain fields based on auto-exposure checkbox
- poll camera exposure/gain while auto-exposure is active so UI shows current values

## Testing
- `python -m py_compile microstage_app/devices/camera_toupcam.py microstage_app/ui/main_window.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b4b0f0c832493cd9587eea565e7