### PR TITLE
Sync UI with camera exposure/gain in auto mode

### DIFF
--- a/microstage_app/devices/camera_mock.py
+++ b/microstage_app/devices/camera_mock.py
@@ -7,6 +7,9 @@ class MockCamera:
         self._latest = None
         self._t = 0.0
         self._resolution_idx = 0
+        self._exposure_ms = 10.0
+        self._auto = False
+        self._gain = 100
 
     def name(self): return "MockCamera"
     def start_stream(self): self._running = True
@@ -44,3 +47,18 @@ class MockCamera:
 
     def get_resolution_index(self):
         return int(self._resolution_idx)
+
+    # Mock exposure/gain -------------------------------------------------------
+
+    def set_exposure_ms(self, ms, auto=False):
+        self._exposure_ms = float(ms)
+        self._auto = bool(auto)
+
+    def get_exposure_ms(self):
+        return float(self._exposure_ms)
+
+    def set_gain(self, gain):
+        self._gain = int(gain)
+
+    def get_gain(self):
+        return int(self._gain)

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -619,7 +619,12 @@ class MainWindow(QtWidgets.QMainWindow):
                 current = int(self.camera.get_resolution_index())
         except Exception:
             current = 0
-        for idx, w, h in self.camera.list_resolutions():
+        res = list(self.camera.list_resolutions())
+        try:
+            self.camera.resolutions = res
+        except Exception:
+            pass
+        for idx, w, h in res:
             self.res_combo.addItem(f"{w}×{h}", idx)
         pos = self.res_combo.findData(current)
         if pos >= 0:


### PR DESCRIPTION
## Summary
- Add exposure and gain tracking methods to `MockCamera`
- Cache camera resolution list when populating combo box

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3f650f148324be0fdb71eb394165