### PR TITLE
Ensure stage callbacks run in GUI thread

### DIFF
--- a/microstage_app/tests/test_dispatch_stage_result.py
+++ b/microstage_app/tests/test_dispatch_stage_result.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+import microstage_app.ui.main_window as mw
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_dispatch_updates_stage_pos(monkeypatch, qt_app):
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_attach_stage_worker", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_update_stage_buttons", lambda self: None)
+
+    win = mw.MainWindow()
+    try:
+        pos = (1.0, 2.0, 3.0)
+        win._dispatch_stage_result(win._on_stage_position, pos)
+        QtWidgets.QApplication.processEvents()
+        assert "X1.000" in win.stage_pos.text()
+    finally:
+        win.preview_timer.stop()
+        win.fps_timer.stop()
+        win.close()

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -422,7 +422,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _dispatch_stage_result(self, cb, res):
         if cb:
-            cb(res)
+            QtCore.QTimer.singleShot(0, lambda r=res: cb(r))
 
     # --------------------------- CONNECT/DISCONNECT ---------------------------
 


### PR DESCRIPTION
## Summary
- Queue stage result callbacks to the main thread using `QtCore.QTimer.singleShot`
- Add test verifying that dispatching a stage position update updates the UI label

## Testing
- `pytest microstage_app/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4478822c83249839384096d96d17