### PR TITLE
Handle optional MaxSpeed API

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -156,7 +156,17 @@ class ToupcamCamera:
 
         # ensure highest bandwidth mode if supported
         try:
-            maxspeed = self._cam.get_MaxSpeed()
+            if hasattr(self._cam, "get_MaxSpeed"):
+                maxspeed = self._cam.get_MaxSpeed()
+            elif hasattr(self._cam, "MaxSpeed"):
+                maxspeed = self._cam.MaxSpeed()
+            else:
+                maxspeed = None
+
+            if maxspeed is None:
+                log("Camera: speed query not supported")
+                return
+
             cur = self._cam.get_Speed() if hasattr(self._cam, "get_Speed") else None
             log(f"Camera: speed levels 0-{maxspeed}, current {cur}")
             if cur is None or cur < maxspeed:

--- a/toupcam.py
+++ b/toupcam.py
@@ -1325,6 +1325,10 @@ class Toupcam:
         """get the maximum speed, 'Frame Speed Level'"""
         return self.__lib.Toupcam_get_MaxSpeed(self.__h)
 
+    def get_MaxSpeed(self):
+        """compatibility alias for MaxSpeed"""
+        return self.MaxSpeed()
+
     def MaxBitDepth(self):
         """get the max bitdepth of this camera, such as 8, 10, 12, 14, 16"""
         return self.__lib.Toupcam_get_MaxBitDepth(self.__h)


### PR DESCRIPTION
## Summary
- Handle cases where get_MaxSpeed or MaxSpeed may be missing
- Add compatibility alias get_MaxSpeed to toupcam wrapper

## Testing
- `pytest` *(fails: AssertionError in resolution combo tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4ad8aa2c8324baa3a3bbf7ac3dea