### PR TITLE
Reset camera streaming flag during resolution probe

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -329,6 +329,7 @@ class ToupcamCamera:
         try:
             if self._is_streaming:
                 self._cam.Stop()
+                self._is_streaming = False
                 was_streaming = True
         except Exception:
             was_streaming = False


### PR DESCRIPTION
## Summary
- Reset `_is_streaming` after stopping camera in `_probe_resolutions` so restart works

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4ecc7a6c83248663fbd3a9a28ca6