### PR TITLE
Probe all Toupcam resolutions

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -416,18 +416,17 @@ class ToupcamCamera:
                 seen.add((w, h))
                 uniq.append((idx, w, h))
 
-        if len(uniq) < 4:
-            try:
-                probes = self._probe_resolutions()
-                for idx, w, h in probes:
-                    if (w, h) not in seen:
-                        seen.add((w, h))
-                        uniq.append((idx, w, h))
-                if not uniq:
-                    return probes
-            except Exception:
-                if not uniq:
-                    return self._probe_resolutions()
+        try:
+            probes = self._probe_resolutions()
+            for idx, w, h in probes:
+                if (w, h) not in seen:
+                    seen.add((w, h))
+                    uniq.append((idx, w, h))
+            if not uniq:
+                return probes
+        except Exception:
+            if not uniq:
+                return self._probe_resolutions()
 
         return uniq
 


### PR DESCRIPTION
## Summary
- always probe supported resolutions and merge with enumerated modes
- ensure halved square resolutions appear in the resolution combo

## Testing
- `python -m py_compile microstage_app/devices/camera_toupcam.py`
- `python -m py_compile microstage_app/ui/main_window.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac4f0f7adc8324b30b2a07a287cdd1