### PR TITLE
Handle 'Count' field robustly when parsing stage positions

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -209,18 +209,26 @@ class StageMarlin:
 
     def get_position(self):
         resp = self.send("M114")
-        before_count = resp.split("Count", 1)[0]
+        before_count = re.split(r"count", resp, flags=re.IGNORECASE)[0]
         x = y = z = None
-        for token in before_count.split():
-            if token.startswith("X:"):
-                try: x = float(token[2:])
-                except ValueError: pass
-            elif token.startswith("Y:"):
-                try: y = float(token[2:])
-                except ValueError: pass
-            elif token.startswith("Z:"):
-                try: z = float(token[2:])
-                except ValueError: pass
+        m = re.search(r"X:\s*([-+]?\d*\.?\d+)", before_count)
+        if m:
+            try:
+                x = float(m.group(1))
+            except ValueError:
+                pass
+        m = re.search(r"Y:\s*([-+]?\d*\.?\d+)", before_count)
+        if m:
+            try:
+                y = float(m.group(1))
+            except ValueError:
+                pass
+        m = re.search(r"Z:\s*([-+]?\d*\.?\d+)", before_count)
+        if m:
+            try:
+                z = float(m.group(1))
+            except ValueError:
+                pass
         return (x, y, z)
 
     def wait_for_moves(self, timeout_s=5.0):


### PR DESCRIPTION
## Summary
- Parse Marlin `M114` responses ignoring case on the `Count` token
- Extract X, Y, and Z values via regex to avoid step counts overriding positions

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7974d108832492747abbf53b6dd5