### PR TITLE
Handle partial stage position updates

### DIFF
--- a/microstage_app/tests/test_dispatch_stage_result.py
+++ b/microstage_app/tests/test_dispatch_stage_result.py
@@ -28,3 +28,22 @@ def test_dispatch_updates_stage_pos(monkeypatch, qt_app):
         win.preview_timer.stop()
         win.fps_timer.stop()
         win.close()
+
+
+def test_dispatch_partial_pos(monkeypatch, qt_app):
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_attach_stage_worker", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_update_stage_buttons", lambda self: None)
+
+    win = mw.MainWindow()
+    try:
+        win._dispatch_stage_result(win._on_stage_position, (1.0, 2.0, 3.0))
+        QtWidgets.QApplication.processEvents()
+        win._dispatch_stage_result(win._on_stage_position, (None, None, 4.0))
+        QtWidgets.QApplication.processEvents()
+        txt = win.stage_pos.text()
+        assert "X1.000" in txt and "Y2.000" in txt and "Z4.000" in txt
+    finally:
+        win.preview_timer.stop()
+        win.fps_timer.stop()
+        win.close()


### PR DESCRIPTION
## Summary
- Cache last-known stage coordinates in the main window
- Refresh position label from cached values, updating only provided axes
- Test partial position updates to ensure Z can refresh independently of X/Y

## Testing
- `apt-get install -y libgl1 libxkbcommon0 libegl1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7974df948324b5a12b6c7fb559dd