### PR TITLE
Handle lowercase count in StageMarlin position responses

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -209,7 +209,10 @@ class StageMarlin:
 
     def get_position(self):
         resp = self.send("M114")
-        before_count = resp.split("Count", 1)[0]
+        # Some Marlin builds use lowercase 'count' while others use 'Count';
+        # strip everything after this token case-insensitively so only the
+        # machine coordinates remain.
+        before_count = re.split(r"count", resp, flags=re.IGNORECASE)[0]
         x = y = z = None
         for token in before_count.split():
             if token.startswith("X:"):

--- a/microstage_app/tests/test_stage_marlin_get_position.py
+++ b/microstage_app/tests/test_stage_marlin_get_position.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+
+from microstage_app.devices.stage_marlin import StageMarlin
+import microstage_app.ui.main_window as mw
+
+
+class FakeStage(StageMarlin):
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def send(self, cmd, wait_ok=True):  # pragma: no cover - trivial
+        return self._responses.pop(0)
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_get_position_and_label(monkeypatch, qt_app):
+    responses = [
+        "X:0.00 Y:0.00 Z:1.00 E:0.00 count X:0 Y:0 Z:0",
+        "X:0.00 Y:0.00 Z:2.00 E:0.00 count X:0 Y:0 Z:0",
+    ]
+    stage = FakeStage(responses)
+    z1 = stage.get_position()[2]
+    assert z1 == 1.0
+    z2 = stage.get_position()[2]
+    assert z2 == 2.0
+
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_attach_stage_worker", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_update_stage_buttons", lambda self: None)
+
+    win = mw.MainWindow()
+    try:
+        win._on_stage_position((0.0, 0.0, z1))
+        QtWidgets.QApplication.processEvents()
+        assert "Z1.000" in win.stage_pos.text()
+        win._on_stage_position((0.0, 0.0, z2))
+        QtWidgets.QApplication.processEvents()
+        assert "Z2.000" in win.stage_pos.text()
+    finally:
+        win.preview_timer.stop()
+        win.fps_timer.stop()
+        win.close()


### PR DESCRIPTION
## Summary
- handle lowercase `count` tokens in Marlin M114 responses when parsing positions
- test StageMarlin.get_position and label update from `_on_stage_position`

## Testing
- `pytest microstage_app/tests/test_stage_marlin_get_position.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7975b890832484765fb632b84c9c