### PR TITLE
Add capture directory and auto-numbering options

### DIFF
--- a/microstage_app/io/storage.py
+++ b/microstage_app/io/storage.py
@@ -9,8 +9,33 @@ class ImageWriter:
         self.run_dir = os.path.join(self.base_dir, ts)
         os.makedirs(self.run_dir, exist_ok=True)
 
-    def save_single(self, img_rgb):
-        path = os.path.join(self.run_dir, 'capture.tif')
+    def save_single(self, img_rgb, directory=None, filename="capture", auto_number=False):
+        """Save a single image.
+
+        Parameters
+        ----------
+        img_rgb : array-like
+            RGB image data.
+        directory : str or None
+            Destination directory. Defaults to ``self.run_dir``.
+        filename : str
+            Base filename without extension.
+        auto_number : bool
+            If ``True``, append ``_n`` to ``filename`` where ``n`` increments
+            to avoid overwriting existing files.
+        """
+
+        directory = directory or self.run_dir
+        os.makedirs(directory, exist_ok=True)
+        base = os.path.join(directory, f"{filename}.tif")
+        path = base
+        if auto_number and os.path.exists(path):
+            n = 1
+            while True:
+                path = os.path.join(directory, f"{filename}_{n}.tif")
+                if not os.path.exists(path):
+                    break
+                n += 1
         self._save_tiff(path, img_rgb)
 
     def save_tile(self, img_rgb, row, col):

--- a/microstage_app/tests/test_image_writer.py
+++ b/microstage_app/tests/test_image_writer.py
@@ -1,0 +1,22 @@
+import numpy as np
+from microstage_app.io.storage import ImageWriter
+
+
+def test_save_single_custom_dir_and_name(tmp_path):
+    writer = ImageWriter(base_dir=str(tmp_path / "runs"))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    out_dir = tmp_path / "custom"
+    writer.save_single(img, directory=str(out_dir), filename="foo")
+    assert (out_dir / "foo.tif").exists()
+
+
+def test_save_single_autonumber(tmp_path):
+    writer = ImageWriter(base_dir=str(tmp_path / "runs"))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    out_dir = tmp_path / "auto"
+    writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
+    writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
+    writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
+    assert (out_dir / "foo.tif").exists()
+    assert (out_dir / "foo_1.tif").exists()
+    assert (out_dir / "foo_2.tif").exists()


### PR DESCRIPTION
## Summary
- allow setting capture directory, base filename, and auto-numbering from UI
- extend ImageWriter to handle custom paths and sequential numbering
- cover new behavior with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad9e64d9308324ac153a92901d9afe