### PR TITLE
Validate capture path and filename

### DIFF
--- a/microstage_app/tests/test_capture_validation.py
+++ b/microstage_app/tests/test_capture_validation.py
@@ -1,0 +1,66 @@
+import os
+
+import pytest
+from PySide6 import QtWidgets
+
+import microstage_app.ui.main_window as mw
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+@pytest.fixture
+def win(monkeypatch, qt_app):
+    w = mw.MainWindow()
+    w.stage = object()
+    w.camera = object()
+    monkeypatch.setattr(mw, "run_async", lambda fn: pytest.fail("run_async called"))
+    yield w
+    w.preview_timer.stop()
+    w.fps_timer.stop()
+    w.close()
+
+
+def test_capture_empty_filename(monkeypatch, tmp_path, win):
+    win.capture_dir = str(tmp_path)
+    win.capture_name = ""
+    messages = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "critical", lambda *args: messages.append(args[2])
+    )
+    win._capture()
+    assert messages == ["Filename cannot be empty."]
+
+
+def test_capture_illegal_filename(monkeypatch, tmp_path, win):
+    win.capture_dir = str(tmp_path)
+    win.capture_name = "bad:name"
+    messages = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "critical", lambda *args: messages.append(args[2])
+    )
+    win._capture()
+    assert "illegal characters" in messages[0]
+
+
+def test_capture_uncreatable_directory(monkeypatch, tmp_path, win):
+    win.capture_dir = str(tmp_path / "sub")
+    win.capture_name = "ok"
+    messages = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "critical", lambda *args: messages.append(args[2])
+    )
+
+    def fail_makedirs(path, exist_ok=False):
+        raise OSError("fail")
+
+    monkeypatch.setattr(mw.os, "makedirs", fail_makedirs)
+    win._capture()
+    assert "Unable to create directory" in messages[0]
+

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -954,12 +954,45 @@ class MainWindow(QtWidgets.QMainWindow):
         name = self.capture_name
         auto_num = self.auto_number
 
+        # validate directory
+        if not directory:
+            log("Capture aborted: directory not specified")
+            QtWidgets.QMessageBox.critical(
+                self, "Capture", "Capture directory is not set."
+            )
+            return
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except OSError as e:
+            log(f"Capture aborted: cannot create directory {directory}: {e}")
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Capture",
+                f"Unable to create directory:\n{directory}\n{e}",
+            )
+            return
+
+        # validate filename
+        if not name:
+            log("Capture aborted: filename empty")
+            QtWidgets.QMessageBox.critical(
+                self, "Capture", "Filename cannot be empty."
+            )
+            return
+        if re.search(r"[\\/:*?\"<>|]", name):
+            log("Capture aborted: illegal characters in filename")
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Capture",
+                "Filename contains illegal characters (\\ / : * ? \" < > |).",
+            )
+            return
+
         def do_capture():
             self.stage.wait_for_moves()
             time.sleep(0.03)
             img = self.camera.snap()
             if img is not None:
-                os.makedirs(directory, exist_ok=True)
                 self.image_writer.save_single(
                     img, directory=directory, filename=name, auto_number=auto_num
                 )


### PR DESCRIPTION
## Summary
- validate capture directory exists or can be created and show errors
- prevent empty or illegal capture filenames
- add tests covering invalid directory and filename cases

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad9f94799883248acb75e5478b2520