### PR TITLE
Persist capture settings

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -3,7 +3,11 @@ import yaml, os
 DEFAULTS = {
     'stage': {'feed_mm_s': 20.0 / 60.0, 'settle_ms': 30},
     'camera': {'exposure_ms': 10.0, 'gain': 1.0, 'binning': 1},
-    'scan_presets': {'raster': {'pitch_x_mm': 1.0, 'pitch_y_mm': 1.0, 'rows': 5, 'cols': 5}}
+    'scan_presets': {
+        'raster': {'pitch_x_mm': 1.0, 'pitch_y_mm': 1.0, 'rows': 5, 'cols': 5}
+    },
+    # persistent capture settings
+    'capture': {'dir': '', 'name': 'capture', 'auto_number': False},
 }
 
 class Profiles:
@@ -23,3 +27,14 @@ class Profiles:
             if key in cur: cur = cur[key]
             else: return default
         return cur
+
+    def set(self, path: str, value):
+        cur = self.data
+        keys = path.split('.')
+        for key in keys[:-1]:
+            cur = cur.setdefault(key, {})
+        cur[keys[-1]] = value
+
+    def save(self):
+        with open(self.PATH, 'w') as f:
+            yaml.safe_dump(self.data, f)

--- a/microstage_app/tests/test_capture_settings_persist.py
+++ b/microstage_app/tests/test_capture_settings_persist.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+
+import microstage_app.ui.main_window as mw
+from microstage_app.control.profiles import Profiles
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_capture_settings_persist(monkeypatch, tmp_path, qt_app):
+    # use temp profiles file
+    monkeypatch.setattr(Profiles, "PATH", str(tmp_path / "profiles.yaml"))
+
+    # stub ImageWriter to avoid filesystem churn
+    def fake_init(self, base_dir='runs'):
+        self.base_dir = base_dir
+        self.run_dir = str(tmp_path / "runs")
+    monkeypatch.setattr(mw.ImageWriter, "__init__", fake_init)
+
+    # prevent auto-connect to hardware
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    # first session: change settings
+    win1 = mw.MainWindow()
+    dir1 = str(tmp_path / "out")
+    win1.capture_dir_edit.setText(dir1)
+    win1.capture_name_edit.setText("foo")
+    win1.autonumber_chk.setChecked(True)
+    qt_app.processEvents()
+    win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
+
+    # second session: values should persist
+    win2 = mw.MainWindow()
+    assert win2.capture_dir == dir1
+    assert win2.capture_dir_edit.text() == dir1
+    assert win2.capture_name == "foo"
+    assert win2.capture_name_edit.text() == "foo"
+    assert win2.auto_number is True
+    assert win2.autonumber_chk.isChecked()
+    win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -86,12 +86,15 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # image writer (per-run folder)
         self.image_writer = ImageWriter()
-        self.capture_dir = self.image_writer.run_dir
-        self.capture_name = "capture"
-        self.auto_number = False
 
         # profiles
         self.profiles = Profiles.load_or_create()
+
+        # capture settings
+        dir_profile = self.profiles.get('capture.dir')
+        self.capture_dir = dir_profile if dir_profile else self.image_writer.run_dir
+        self.capture_name = self.profiles.get('capture.name', "capture")
+        self.auto_number = self.profiles.get('capture.auto_number', False)
 
         # timers
         self.preview_timer = QtCore.QTimer(self)
@@ -249,6 +252,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.capture_name_edit = QtWidgets.QLineEdit(self.capture_name)
         ctr4.addWidget(self.capture_name_edit)
         self.autonumber_chk = QtWidgets.QCheckBox("Auto-number (_n)")
+        self.autonumber_chk.setChecked(self.auto_number)
         ctr4.addWidget(self.autonumber_chk)
         ctr4.addStretch(1)
         center.addLayout(ctr4)
@@ -439,12 +443,18 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_capture_dir_changed(self, text: str):
         self.capture_dir = text
+        self.profiles.set('capture.dir', text)
+        self.profiles.save()
 
     def _on_capture_name_changed(self, text: str):
         self.capture_name = text
+        self.profiles.set('capture.name', text)
+        self.profiles.save()
 
     def _on_autonumber_toggled(self, checked: bool):
         self.auto_number = checked
+        self.profiles.set('capture.auto_number', checked)
+        self.profiles.save()
 
     def _browse_capture_dir(self):
         d = QtWidgets.QFileDialog.getExistingDirectory(


### PR DESCRIPTION
## Summary
- persist capture directory, filename, and auto-number in profiles
- load saved capture settings when building UI and write back on change
- add tests verifying capture settings persist between sessions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ada2424afc8324924275ce0cba0d88