### PR TITLE
Document capture output settings and add UI tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
 - Profiles & presets: YAML, per-device and per-scan; import/export.
 - Robustness: hot-plug (to be expanded), watchdogs (to be expanded), structured logs.
 - Scripting: run custom recipes from `microstage_app/scripts/` with a safe API.
+- Validated capture directory/filename fields with optional auto-numbering to prevent overwrites.
+
+## Capture directory & file naming
+
+The capture panel lets you choose an output folder and base filename. The fields
+are validated: the directory must be writable (it will be created if missing) and
+the name cannot contain characters such as `\\ / : * ? \" < > |`. The directory,
+base name, and auto-number option are all remembered between runs.
+
+Enabling **Auto-number (_n)** appends an incrementing suffix when a file with the
+same name already exists, preventing accidental overwrites.
+
+Example usage:
+
+1. Set directory to `C:/data/run1` and base name `sample`.
+2. Check **Auto-number (_n)**.
+3. Click **Capture** repeatedly to produce `sample.tif`,
+   `sample_1.tif`, `sample_2.tif`, …
 
 ## Packaging
 ```bash

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -242,6 +242,11 @@ class MainWindow(QtWidgets.QMainWindow):
         ctr3 = QtWidgets.QHBoxLayout()
         ctr3.addWidget(QtWidgets.QLabel("Dir:"))
         self.capture_dir_edit = QtWidgets.QLineEdit(self.capture_dir)
+        self.capture_dir_edit.setPlaceholderText("Folder for captures")
+        self.capture_dir_edit.setToolTip(
+            "Destination folder for captured images. Created if missing and "
+            "remembered between sessions."
+        )
         ctr3.addWidget(self.capture_dir_edit, 1)
         self.btn_browse_dir = QtWidgets.QPushButton("Browse...")
         ctr3.addWidget(self.btn_browse_dir)
@@ -250,9 +255,18 @@ class MainWindow(QtWidgets.QMainWindow):
         ctr4 = QtWidgets.QHBoxLayout()
         ctr4.addWidget(QtWidgets.QLabel("Base name:"))
         self.capture_name_edit = QtWidgets.QLineEdit(self.capture_name)
+        self.capture_name_edit.setPlaceholderText("Base filename")
+        self.capture_name_edit.setToolTip(
+            "Base filename without extension. Must not be empty or contain "
+            "\\ / : * ? \" < > |. Saved between sessions."
+        )
         ctr4.addWidget(self.capture_name_edit)
         self.autonumber_chk = QtWidgets.QCheckBox("Auto-number (_n)")
         self.autonumber_chk.setChecked(self.auto_number)
+        self.autonumber_chk.setToolTip(
+            "If enabled, append an incrementing _n suffix when a file with "
+            "the same name exists to avoid overwriting. Setting persists."
+        )
         ctr4.addWidget(self.autonumber_chk)
         ctr4.addStretch(1)
         center.addLayout(ctr4)


### PR DESCRIPTION
## Summary
- explain capture directory, filename and auto-numbering in README
- add tooltips and placeholders for capture directory, base name and auto-number options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada74417ac8324a57602bce1bde43a