### PR TITLE
Validate autofocus step sizes

### DIFF
--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -25,6 +25,8 @@ class AutoFocus:
         self.camera = camera
 
     def coarse_to_fine(self, metric: FocusMetric, z_range_mm=0.5, coarse_step_mm=0.01, fine_step_mm=0.002):
+        if coarse_step_mm <= 0 or fine_step_mm <= 0:
+            raise ValueError("coarse_step_mm and fine_step_mm must be > 0")
         samples = []
         steps = int(max(1, round(z_range_mm / coarse_step_mm)))
         zs = [(-steps + i) * coarse_step_mm for i in range(2*steps + 1)]

--- a/microstage_app/tests/test_autofocus.py
+++ b/microstage_app/tests/test_autofocus.py
@@ -1,5 +1,6 @@
 import microstage_app.control.autofocus as af
 from microstage_app.control.autofocus import AutoFocus, FocusMetric
+import pytest
 
 class StageMock:
     def __init__(self):
@@ -23,3 +24,13 @@ def test_autofocus_converges(monkeypatch):
     autofocus = AutoFocus(stage, cam)
     best = autofocus.coarse_to_fine(FocusMetric.LAPLACIAN, z_range_mm=0.2, coarse_step_mm=0.1, fine_step_mm=0.05)
     assert abs(best) < 1e-6
+
+
+def test_autofocus_zero_step_raises():
+    stage = StageMock()
+    cam = CameraMock()
+    autofocus = AutoFocus(stage, cam)
+    with pytest.raises(ValueError):
+        autofocus.coarse_to_fine(FocusMetric.LAPLACIAN, coarse_step_mm=0.0)
+    with pytest.raises(ValueError):
+        autofocus.coarse_to_fine(FocusMetric.LAPLACIAN, fine_step_mm=0.0)

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1048,6 +1048,12 @@ class MainWindow(QtWidgets.QMainWindow):
             log("Autofocus ignored: stage or camera not connected")
             return
 
+        coarse = float(self.af_coarse.value())
+        fine = float(self.af_fine.value())
+        if coarse <= 0 or fine <= 0:
+            QtWidgets.QMessageBox.warning(self, "Autofocus", "Coarse and fine steps must be > 0")
+            return
+
         metric = FocusMetric(self.metric_combo.currentText())
         self._autofocusing = True
         self.btn_autofocus.setEnabled(False)


### PR DESCRIPTION
## Summary
- Add safeguards in `AutoFocus.coarse_to_fine` to reject non-positive step sizes
- Ensure UI autofocus routine validates step settings and notifies users when invalid
- Test that zero step sizes raise `ValueError`

## Testing
- `pytest microstage_app/tests/test_autofocus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc940aa248324a663bc2f5228051c