### PR TITLE
Move autofocus controls into left column

### DIFF
--- a/microstage_app/tests/test_af_spinbox_decimals.py
+++ b/microstage_app/tests/test_af_spinbox_decimals.py
@@ -18,6 +18,14 @@ def test_af_spinboxes_three_decimals(monkeypatch, qt_app):
 
     win = mw.MainWindow()
 
+    # Ensure autofocus controls live in a group box and not a tab
+    tabs = win.findChildren(QtWidgets.QTabWidget)
+    assert all(
+        tab.tabText(i) != "Autofocus" for tab in tabs for i in range(tab.count())
+    )
+    af_boxes = [b for b in win.findChildren(QtWidgets.QGroupBox) if b.title() == "Autofocus"]
+    assert af_boxes, "Autofocus group box not found"
+
     for box in (win.af_coarse, win.af_fine):
         assert box.decimals() == 3
 

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -221,6 +221,22 @@ class MainWindow(QtWidgets.QMainWindow):
         j.addWidget(self.absz_spin, 3, 3)
         j.addWidget(self.btn_move_to_coords, 3, 4, 1, 2)
         left.addWidget(jog_box)
+
+        # Autofocus controls moved from right-hand tab to left column
+        af_box = QtWidgets.QGroupBox("Autofocus")
+        a = QtWidgets.QGridLayout(af_box)
+        self.metric_combo = QtWidgets.QComboBox(); self.metric_combo.addItems([m.value for m in FocusMetric])
+        self.af_range = QtWidgets.QDoubleSpinBox(); self.af_range.setRange(0.01, 5.0); self.af_range.setValue(0.5)
+        self.af_coarse = QtWidgets.QDoubleSpinBox(); self.af_coarse.setDecimals(3); self.af_coarse.setRange(0.001, 1.0); self.af_coarse.setValue(0.01)
+        self.af_fine = QtWidgets.QDoubleSpinBox(); self.af_fine.setDecimals(3); self.af_fine.setRange(0.0005, 0.2); self.af_fine.setValue(0.002)
+        self.btn_autofocus = QtWidgets.QPushButton("Run Autofocus")
+        a.addWidget(QtWidgets.QLabel("Metric:"), 0, 0); a.addWidget(self.metric_combo, 0, 1)
+        a.addWidget(QtWidgets.QLabel("Range (mm):"), 1, 0); a.addWidget(self.af_range, 1, 1)
+        a.addWidget(QtWidgets.QLabel("Coarse step (mm):"), 2, 0); a.addWidget(self.af_coarse, 2, 1)
+        a.addWidget(QtWidgets.QLabel("Fine step (mm):"), 3, 0); a.addWidget(self.af_fine, 3, 1)
+        a.addWidget(self.btn_autofocus, 4, 0, 1, 2)
+        left.addWidget(af_box)
+
         left.addStretch(1)
         left.addWidget(self.stage_pos)
 
@@ -333,21 +349,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
         c.setRowStretch(row, 1)
         rightw.addTab(camtab, "Camera")
-
-        # ---- Autofocus tab
-        af = QtWidgets.QWidget()
-        a = QtWidgets.QGridLayout(af)
-        self.metric_combo = QtWidgets.QComboBox(); self.metric_combo.addItems([m.value for m in FocusMetric])
-        self.af_range = QtWidgets.QDoubleSpinBox(); self.af_range.setRange(0.01, 5.0); self.af_range.setValue(0.5)
-        self.af_coarse = QtWidgets.QDoubleSpinBox(); self.af_coarse.setDecimals(3); self.af_coarse.setRange(0.001, 1.0); self.af_coarse.setValue(0.01)
-        self.af_fine = QtWidgets.QDoubleSpinBox(); self.af_fine.setDecimals(3); self.af_fine.setRange(0.0005, 0.2); self.af_fine.setValue(0.002)
-        self.btn_autofocus = QtWidgets.QPushButton("Run Autofocus")
-        a.addWidget(QtWidgets.QLabel("Metric:"), 0, 0); a.addWidget(self.metric_combo, 0, 1)
-        a.addWidget(QtWidgets.QLabel("Range (mm):"), 1, 0); a.addWidget(self.af_range, 1, 1)
-        a.addWidget(QtWidgets.QLabel("Coarse step (mm):"), 2, 0); a.addWidget(self.af_coarse, 2, 1)
-        a.addWidget(QtWidgets.QLabel("Fine step (mm):"), 3, 0); a.addWidget(self.af_fine, 3, 1)
-        a.addWidget(self.btn_autofocus, 4, 0, 1, 2)
-        rightw.addTab(af, "Autofocus")
 
         # ---- Raster tab
         rast = QtWidgets.QWidget()


### PR DESCRIPTION
## Summary
- Remove Autofocus tab and place its controls in a new left-column group box
- Update autofocus spinbox test to ensure controls are in the group box and no Autofocus tab remains

## Testing
- `pytest microstage_app/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68adccbffbac8324a41f12a87ea42347