### PR TITLE
Expose autofocus feed rate

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1066,6 +1066,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 z_range_mm=float(self.af_range.value()),
                 coarse_step_mm=float(self.af_coarse.value()),
                 fine_step_mm=float(self.af_fine.value()),
+                feed_mm_per_min=self.feedz_spin.value(),
             )
             return best_z
 


### PR DESCRIPTION
## Summary
- Allow `AutoFocus.coarse_to_fine` to accept a feed rate and use it for all stage moves
- Pass the Z feed rate from the UI into autofocus
- Expand tests to capture and assert the feed rate

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adf78ab2b08324af1b845c3d47be10