### PR TITLE
Start ImageWriter auto-numbering at 1

### DIFF
--- a/microstage_app/io/storage.py
+++ b/microstage_app/io/storage.py
@@ -42,15 +42,15 @@ class ImageWriter:
             "jpeg": "jpg",
         }.get(fmt, "bmf")
 
-        base = os.path.join(directory, f"{filename}.{ext}")
-        path = base
-        if auto_number and os.path.exists(path):
+        if auto_number:
             n = 1
             while True:
                 path = os.path.join(directory, f"{filename}_{n}.{ext}")
                 if not os.path.exists(path):
                     break
                 n += 1
+        else:
+            path = os.path.join(directory, f"{filename}.{ext}")
 
         if ext in ("tif", "bmf"):
             self._save_tiff(path, img_rgb)

--- a/microstage_app/tests/test_image_writer.py
+++ b/microstage_app/tests/test_image_writer.py
@@ -16,8 +16,7 @@ def test_save_single_autonumber(tmp_path):
     out_dir = tmp_path / "auto"
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    assert (out_dir / "foo.bmf").exists()
+    assert not (out_dir / "foo.bmf").exists()
     assert (out_dir / "foo_1.bmf").exists()
     assert (out_dir / "foo_2.bmf").exists()
 

--- a/tests/test_image_writer.py
+++ b/tests/test_image_writer.py
@@ -37,8 +37,7 @@ def test_filename_generation_with_auto_numbering(tmp_path):
     out_dir = tmp_path / "auto"
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    assert (out_dir / "foo.bmf").exists()
+    assert not (out_dir / "foo.bmf").exists()
     assert (out_dir / "foo_1.bmf").exists()
     assert (out_dir / "foo_2.bmf").exists()
 


### PR DESCRIPTION
## Summary
- start auto-numbered image saving at `filename_1.ext`
- adjust ImageWriter tests for new numbering scheme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adfefeeaf083248d6c86d2f71d00ac