### PR TITLE
Add BMP capture format and storage support

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -7,7 +7,7 @@ DEFAULTS = {
         'raster': {'pitch_x_mm': 1.0, 'pitch_y_mm': 1.0, 'rows': 5, 'cols': 5}
     },
     # persistent capture settings
-    'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'bmf'},
+    'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'bmp'},
 }
 
 class Profiles:

--- a/microstage_app/io/storage.py
+++ b/microstage_app/io/storage.py
@@ -10,7 +10,7 @@ class ImageWriter:
         self.run_dir = os.path.join(self.base_dir, ts)
         os.makedirs(self.run_dir, exist_ok=True)
 
-    def save_single(self, img_rgb, directory=None, filename="capture", auto_number=False, fmt="bmf"):
+    def save_single(self, img_rgb, directory=None, filename="capture", auto_number=False, fmt="bmp"):
         """Save a single image.
 
         Parameters
@@ -25,22 +25,21 @@ class ImageWriter:
             If ``True``, append ``_n`` to ``filename`` where ``n`` increments
             to avoid overwriting existing files.
         fmt : str
-            Image format/extension. ``bmf`` (default) behaves like TIFF but
-            uses the ``.bmf`` extension. Other supported formats are ``tif``,
-            ``png`` and ``jpg``.
+            Image format/extension. ``bmp`` (default). Supported formats are
+            ``bmp``, ``tif``, ``png`` and ``jpg``.
         """
 
         directory = directory or self.run_dir
         os.makedirs(directory, exist_ok=True)
         fmt = fmt.lower()
         ext = {
-            "bmf": "bmf",
+            "bmp": "bmp",
             "tif": "tif",
             "tiff": "tif",
             "png": "png",
             "jpg": "jpg",
             "jpeg": "jpg",
-        }.get(fmt, "bmf")
+        }.get(fmt, "bmp")
 
         if auto_number:
             n = 1
@@ -52,14 +51,14 @@ class ImageWriter:
         else:
             path = os.path.join(directory, f"{filename}.{ext}")
 
-        if ext in ("tif", "bmf"):
+        if ext == "tif":
             self._save_tiff(path, img_rgb)
         elif ext == "png":
             self._save_png(path, img_rgb)
         elif ext == "jpg":
             self._save_jpg(path, img_rgb)
         else:
-            self._save_tiff(path, img_rgb)
+            self._save_bmp(path, img_rgb)
 
     def save_tile(self, img_rgb, row, col):
         path = os.path.join(self.run_dir, f'tile_r{row:04d}_c{col:04d}.tif')
@@ -73,3 +72,6 @@ class ImageWriter:
 
     def _save_jpg(self, path, img_rgb):
         Image.fromarray(img_rgb).save(path, format="JPEG")
+
+    def _save_bmp(self, path, img_rgb):
+        Image.fromarray(img_rgb).save(path, format="BMP")

--- a/microstage_app/tests/test_capture_settings_persist.py
+++ b/microstage_app/tests/test_capture_settings_persist.py
@@ -34,6 +34,9 @@ def test_capture_settings_persist(monkeypatch, tmp_path, qt_app):
     win1.capture_dir_edit.setText(dir1)
     win1.capture_name_edit.setText("foo")
     win1.autonumber_chk.setChecked(True)
+    assert win1.capture_format == "bmp"
+    assert win1.format_combo.currentText() == "BMP"
+    win1.format_combo.setCurrentText("PNG")
     qt_app.processEvents()
     win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
 
@@ -45,4 +48,6 @@ def test_capture_settings_persist(monkeypatch, tmp_path, qt_app):
     assert win2.capture_name_edit.text() == "foo"
     assert win2.auto_number is True
     assert win2.autonumber_chk.isChecked()
+    assert win2.capture_format == "png"
+    assert win2.format_combo.currentText() == "PNG"
     win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()

--- a/microstage_app/tests/test_image_writer.py
+++ b/microstage_app/tests/test_image_writer.py
@@ -7,7 +7,7 @@ def test_save_single_custom_dir_and_name(tmp_path):
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     out_dir = tmp_path / "custom"
     writer.save_single(img, directory=str(out_dir), filename="foo")
-    assert (out_dir / "foo.bmf").exists()
+    assert (out_dir / "foo.bmp").exists()
 
 
 def test_save_single_autonumber(tmp_path):
@@ -16,9 +16,9 @@ def test_save_single_autonumber(tmp_path):
     out_dir = tmp_path / "auto"
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    assert not (out_dir / "foo.bmf").exists()
-    assert (out_dir / "foo_1.bmf").exists()
-    assert (out_dir / "foo_2.bmf").exists()
+    assert not (out_dir / "foo.bmp").exists()
+    assert (out_dir / "foo_1.bmp").exists()
+    assert (out_dir / "foo_2.bmp").exists()
 
 
 def test_save_png(tmp_path):

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -95,7 +95,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.capture_dir = dir_profile if dir_profile else self.image_writer.run_dir
         self.capture_name = self.profiles.get('capture.name', "capture")
         self.auto_number = self.profiles.get('capture.auto_number', False)
-        self.capture_format = self.profiles.get('capture.format', 'bmf')
+        self.capture_format = self.profiles.get('capture.format', 'bmp')
 
         # timers
         self.preview_timer = QtCore.QTimer(self)
@@ -287,7 +287,7 @@ class MainWindow(QtWidgets.QMainWindow):
         ctr4.addWidget(self.autonumber_chk)
         ctr4.addWidget(QtWidgets.QLabel("Format:"))
         self.format_combo = QtWidgets.QComboBox()
-        self.format_combo.addItems(["BMF", "TIF", "PNG", "JPG"])
+        self.format_combo.addItems(["BMP", "TIF", "PNG", "JPG"])
         self.format_combo.setCurrentText(self.capture_format.upper())
         self.format_combo.setToolTip("Image file format for captures")
         ctr4.addWidget(self.format_combo)

--- a/tests/test_image_writer.py
+++ b/tests/test_image_writer.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 
 import numpy as np
-import tifffile
+from PIL import Image
 
 # Ensure the repository root is on sys.path so ``microstage_app`` is importable
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -15,7 +15,7 @@ def test_save_to_custom_directory(tmp_path):
     out_dir = tmp_path / "existing"
     out_dir.mkdir()
     writer.save_single(img, directory=str(out_dir), filename="foo")
-    assert (out_dir / "foo.bmf").exists()
+    assert (out_dir / "foo.bmp").exists()
 
 
 def test_filename_without_auto_numbering_overwrites(tmp_path):
@@ -25,9 +25,9 @@ def test_filename_without_auto_numbering_overwrites(tmp_path):
     out_dir = tmp_path / "non_auto"
     writer.save_single(img1, directory=str(out_dir), filename="foo", auto_number=False)
     writer.save_single(img2, directory=str(out_dir), filename="foo", auto_number=False)
-    assert (out_dir / "foo.bmf").exists()
-    assert not (out_dir / "foo_1.bmf").exists()
-    saved = tifffile.imread(out_dir / "foo.bmf")
+    assert (out_dir / "foo.bmp").exists()
+    assert not (out_dir / "foo_1.bmp").exists()
+    saved = np.array(Image.open(out_dir / "foo.bmp"))
     assert (saved == img2).all()
 
 
@@ -37,9 +37,9 @@ def test_filename_generation_with_auto_numbering(tmp_path):
     out_dir = tmp_path / "auto"
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    assert not (out_dir / "foo.bmf").exists()
-    assert (out_dir / "foo_1.bmf").exists()
-    assert (out_dir / "foo_2.bmf").exists()
+    assert not (out_dir / "foo.bmp").exists()
+    assert (out_dir / "foo_1.bmp").exists()
+    assert (out_dir / "foo_2.bmp").exists()
 
 
 def test_creates_missing_directory(tmp_path):
@@ -47,7 +47,7 @@ def test_creates_missing_directory(tmp_path):
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     out_dir = tmp_path / "missing" / "subdir"
     writer.save_single(img, directory=str(out_dir), filename="foo")
-    assert (out_dir / "foo.bmf").exists()
+    assert (out_dir / "foo.bmp").exists()
 
 
 def test_save_with_explicit_format(tmp_path):


### PR DESCRIPTION
## Summary
- default capture format switched to BMP across UI and profiles
- extend ImageWriter to save BMP images via Pillow
- update tests to cover BMP format and persistent profile selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae032740248324a9f2fa36ce118785