### PR TITLE
Switch tests to BMP image format

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -7,7 +7,7 @@ DEFAULTS = {
         'raster': {'pitch_x_mm': 1.0, 'pitch_y_mm': 1.0, 'rows': 5, 'cols': 5}
     },
     # persistent capture settings
-    'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'bmf'},
+    'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'bmp'},
 }
 
 class Profiles:

--- a/microstage_app/io/storage.py
+++ b/microstage_app/io/storage.py
@@ -10,7 +10,7 @@ class ImageWriter:
         self.run_dir = os.path.join(self.base_dir, ts)
         os.makedirs(self.run_dir, exist_ok=True)
 
-    def save_single(self, img_rgb, directory=None, filename="capture", auto_number=False, fmt="bmf"):
+    def save_single(self, img_rgb, directory=None, filename="capture", auto_number=False, fmt="bmp"):
         """Save a single image.
 
         Parameters
@@ -25,22 +25,21 @@ class ImageWriter:
             If ``True``, append ``_n`` to ``filename`` where ``n`` increments
             to avoid overwriting existing files.
         fmt : str
-            Image format/extension. ``bmf`` (default) behaves like TIFF but
-            uses the ``.bmf`` extension. Other supported formats are ``tif``,
-            ``png`` and ``jpg``.
+            Image format/extension. ``bmp`` (default) along with ``tif``,
+            ``png`` and ``jpg`` are supported.
         """
 
         directory = directory or self.run_dir
         os.makedirs(directory, exist_ok=True)
         fmt = fmt.lower()
         ext = {
-            "bmf": "bmf",
+            "bmp": "bmp",
             "tif": "tif",
             "tiff": "tif",
             "png": "png",
             "jpg": "jpg",
             "jpeg": "jpg",
-        }.get(fmt, "bmf")
+        }.get(fmt, "bmp")
 
         if auto_number:
             n = 1
@@ -52,12 +51,14 @@ class ImageWriter:
         else:
             path = os.path.join(directory, f"{filename}.{ext}")
 
-        if ext in ("tif", "bmf"):
+        if ext == "tif":
             self._save_tiff(path, img_rgb)
         elif ext == "png":
             self._save_png(path, img_rgb)
         elif ext == "jpg":
             self._save_jpg(path, img_rgb)
+        elif ext == "bmp":
+            self._save_bmp(path, img_rgb)
         else:
             self._save_tiff(path, img_rgb)
 
@@ -73,3 +74,6 @@ class ImageWriter:
 
     def _save_jpg(self, path, img_rgb):
         Image.fromarray(img_rgb).save(path, format="JPEG")
+
+    def _save_bmp(self, path, img_rgb):
+        Image.fromarray(img_rgb).save(path, format="BMP")

--- a/microstage_app/tests/test_image_writer.py
+++ b/microstage_app/tests/test_image_writer.py
@@ -7,7 +7,7 @@ def test_save_single_custom_dir_and_name(tmp_path):
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     out_dir = tmp_path / "custom"
     writer.save_single(img, directory=str(out_dir), filename="foo")
-    assert (out_dir / "foo.bmf").exists()
+    assert (out_dir / "foo.bmp").exists()
 
 
 def test_save_single_autonumber(tmp_path):
@@ -16,9 +16,9 @@ def test_save_single_autonumber(tmp_path):
     out_dir = tmp_path / "auto"
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    assert not (out_dir / "foo.bmf").exists()
-    assert (out_dir / "foo_1.bmf").exists()
-    assert (out_dir / "foo_2.bmf").exists()
+    assert not (out_dir / "foo.bmp").exists()
+    assert (out_dir / "foo_1.bmp").exists()
+    assert (out_dir / "foo_2.bmp").exists()
 
 
 def test_save_png(tmp_path):

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -95,7 +95,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.capture_dir = dir_profile if dir_profile else self.image_writer.run_dir
         self.capture_name = self.profiles.get('capture.name', "capture")
         self.auto_number = self.profiles.get('capture.auto_number', False)
-        self.capture_format = self.profiles.get('capture.format', 'bmf')
+        self.capture_format = self.profiles.get('capture.format', 'bmp')
 
         # timers
         self.preview_timer = QtCore.QTimer(self)

--- a/tests/test_image_writer.py
+++ b/tests/test_image_writer.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 
 import numpy as np
-import tifffile
+from PIL import Image
 
 # Ensure the repository root is on sys.path so ``microstage_app`` is importable
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -15,7 +15,7 @@ def test_save_to_custom_directory(tmp_path):
     out_dir = tmp_path / "existing"
     out_dir.mkdir()
     writer.save_single(img, directory=str(out_dir), filename="foo")
-    assert (out_dir / "foo.bmf").exists()
+    assert (out_dir / "foo.bmp").exists()
 
 
 def test_filename_without_auto_numbering_overwrites(tmp_path):
@@ -25,9 +25,9 @@ def test_filename_without_auto_numbering_overwrites(tmp_path):
     out_dir = tmp_path / "non_auto"
     writer.save_single(img1, directory=str(out_dir), filename="foo", auto_number=False)
     writer.save_single(img2, directory=str(out_dir), filename="foo", auto_number=False)
-    assert (out_dir / "foo.bmf").exists()
-    assert not (out_dir / "foo_1.bmf").exists()
-    saved = tifffile.imread(out_dir / "foo.bmf")
+    assert (out_dir / "foo.bmp").exists()
+    assert not (out_dir / "foo_1.bmp").exists()
+    saved = np.array(Image.open(out_dir / "foo.bmp"))
     assert (saved == img2).all()
 
 
@@ -37,9 +37,9 @@ def test_filename_generation_with_auto_numbering(tmp_path):
     out_dir = tmp_path / "auto"
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
     writer.save_single(img, directory=str(out_dir), filename="foo", auto_number=True)
-    assert not (out_dir / "foo.bmf").exists()
-    assert (out_dir / "foo_1.bmf").exists()
-    assert (out_dir / "foo_2.bmf").exists()
+    assert not (out_dir / "foo.bmp").exists()
+    assert (out_dir / "foo_1.bmp").exists()
+    assert (out_dir / "foo_2.bmp").exists()
 
 
 def test_creates_missing_directory(tmp_path):
@@ -47,7 +47,7 @@ def test_creates_missing_directory(tmp_path):
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     out_dir = tmp_path / "missing" / "subdir"
     writer.save_single(img, directory=str(out_dir), filename="foo")
-    assert (out_dir / "foo.bmf").exists()
+    assert (out_dir / "foo.bmp").exists()
 
 
 def test_save_with_explicit_format(tmp_path):


### PR DESCRIPTION
## Summary
- update image writer tests to expect `.bmp` outputs and use Pillow for verification
- default image writer to save BMP files and add BMP support
- update capture defaults to use BMP format

## Testing
- `pytest tests/test_image_writer.py microstage_app/tests/test_image_writer.py -q`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0492e08c8324a67507a007c51eaa