### PR TITLE
Add serpentine column stepping to raster scan

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -17,15 +17,18 @@ class RasterRunner:
         for r in range(self.cfg.rows):
             forward = (r % 2 == 0) or (not self.cfg.serpentine)
             cols = range(self.cfg.cols) if forward else range(self.cfg.cols-1, -1, -1)
+            last_c = self.cfg.cols - 1 if forward else 0
             for c in cols:
                 self.stage.wait_for_moves()
                 time.sleep(0.03)
                 img = self.camera.snap()
                 if img is not None:
                     self.writer.save_tile(img, r, c if forward else (self.cfg.cols-1 - c))
+                if c != last_c:
+                    dx = self.cfg.pitch_x_mm if forward else -self.cfg.pitch_x_mm
+                    self.stage.move_relative(dx=dx)
             if r < self.cfg.rows - 1:
                 self.stage.move_relative(dy=self.cfg.pitch_y_mm)
-            if self.cfg.cols > 1:
-                dx = self.cfg.pitch_x_mm * (self.cfg.cols - 1)
-                # Return to start of next row if needed
-                self.stage.move_relative(dx=-dx)
+                if not self.cfg.serpentine and self.cfg.cols > 1:
+                    dx = -self.cfg.pitch_x_mm * (self.cfg.cols - 1)
+                    self.stage.move_relative(dx=dx)

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -30,4 +30,10 @@ def test_raster_serpentine(monkeypatch):
     runner = RasterRunner(stage, cam, writer, cfg)
     runner.run()
     assert writer.saved == [(1,0,0),(2,0,1),(3,0,2),(4,1,0),(5,1,1),(6,1,2)]
-    assert stage.moves == [(0.0,1.0,0.0),(-2.0,0.0,0.0),(-2.0,0.0,0.0)]
+    assert stage.moves == [
+        (1.0,0.0,0.0),
+        (1.0,0.0,0.0),
+        (0.0,1.0,0.0),
+        (-1.0,0.0,0.0),
+        (-1.0,0.0,0.0),
+    ]


### PR DESCRIPTION
## Summary
- Move the stage by one column after each camera snap
- Support serpentine rasters by alternating X direction without returning to start
- Test that raster runner steps columns and alternates direction correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae133d47f08324b25e900c86be2b28