### PR TITLE
Add feed rate controls to raster scanning

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -8,6 +8,8 @@ class RasterConfig:
     pitch_x_mm: float = 1.0
     pitch_y_mm: float = 1.0
     serpentine: bool = True
+    feed_x_mm_min: float = 20.0
+    feed_y_mm_min: float = 20.0
 
 class RasterRunner:
     def __init__(self, stage, camera, writer, cfg: RasterConfig):
@@ -24,8 +26,8 @@ class RasterRunner:
                 if img is not None:
                     self.writer.save_tile(img, r, c if forward else (self.cfg.cols-1 - c))
             if r < self.cfg.rows - 1:
-                self.stage.move_relative(dy=self.cfg.pitch_y_mm)
+                self.stage.move_relative(dy=self.cfg.pitch_y_mm, feed_mm_per_min=self.cfg.feed_y_mm_min)
             if self.cfg.cols > 1:
                 dx = self.cfg.pitch_x_mm * (self.cfg.cols - 1)
                 # Return to start of next row if needed
-                self.stage.move_relative(dx=-dx)
+                self.stage.move_relative(dx=-dx, feed_mm_per_min=self.cfg.feed_x_mm_min)

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -3,7 +3,7 @@ from microstage_app.control.raster import RasterRunner, RasterConfig
 class StageMock:
     def __init__(self):
         self.moves = []
-    def move_relative(self, dx=0.0, dy=0.0, dz=0.0):
+    def move_relative(self, dx=0.0, dy=0.0, dz=0.0, feed_mm_per_min=0.0):
         self.moves.append((dx, dy, dz))
     def wait_for_moves(self):
         pass

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1201,6 +1201,8 @@ class MainWindow(QtWidgets.QMainWindow):
             cols=self.cols_spin.value(),
             pitch_x_mm=self.pitchx_spin.value(),
             pitch_y_mm=self.pitchy_spin.value(),
+            feed_x_mm_min=self.feedx_spin.value(),
+            feed_y_mm_min=self.feedy_spin.value(),
         )
 
         def do_raster():


### PR DESCRIPTION
## Summary
- Support configurable X and Y feed rates in `RasterConfig`
- Pass feed rate settings from the UI into raster execution
- Apply feed rates when moving the stage during raster runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1407c66c8324af8336e76bc1c226