### PR TITLE
Refactor raster scan to use coordinate matrix

### DIFF
--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -37,3 +37,20 @@ def test_raster_serpentine(monkeypatch):
         (-1.0,0.0,0.0),
         (-1.0,0.0,0.0),
     ]
+
+
+def test_raster_no_serpentine(monkeypatch):
+    stage = StageMock()
+    cam = CameraMock()
+    writer = WriterMock()
+    cfg = RasterConfig(rows=2, cols=3, x1_mm=0.0, y1_mm=0.0, x2_mm=2.0, y2_mm=1.0, serpentine=False)
+    runner = RasterRunner(stage, cam, writer, cfg)
+    runner.run()
+    assert writer.saved == [(1,0,0),(2,0,1),(3,0,2),(4,1,0),(5,1,1),(6,1,2)]
+    assert stage.moves == [
+        (1.0,0.0,0.0),
+        (1.0,0.0,0.0),
+        (-2.0,1.0,0.0),
+        (1.0,0.0,0.0),
+        (1.0,0.0,0.0),
+    ]


### PR DESCRIPTION
## Summary
- generate raster coordinate matrix from two corner points
- scan coordinates in serpentine order ensuring each tile is captured once
- add tests for serpentine and linear rasters

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*
- `pytest microstage_app/tests/test_raster.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1886ee5483248bdfc004fc872889