### PR TITLE
Enable autofocus and optional capture for raster

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -1,6 +1,13 @@
 from dataclasses import dataclass
 import time
 
+try:
+    from .autofocus import AutoFocus, FocusMetric
+except Exception:  # pragma: no cover - autofocus deps may be missing
+    AutoFocus = None
+    class FocusMetric:
+        LAPLACIAN = None
+
 @dataclass
 class RasterConfig:
     rows: int = 5
@@ -12,6 +19,8 @@ class RasterConfig:
     serpentine: bool = True
     feed_x_mm_min: float = 20.0
     feed_y_mm_min: float = 20.0
+    autofocus: bool = False
+    capture: bool = True
 
 class RasterRunner:
     def __init__(self, stage, camera, writer, cfg: RasterConfig):
@@ -54,8 +63,13 @@ class RasterRunner:
 
                 self.stage.wait_for_moves()
                 time.sleep(0.03)
-                img = self.camera.snap()
-                if img is not None:
+
+                if self.cfg.autofocus and AutoFocus:
+                    af = AutoFocus(self.stage, self.camera)
+                    af.coarse_to_fine(metric=FocusMetric.LAPLACIAN)
+
+                img = self.camera.snap() if self.cfg.capture else None
+                if img is not None and self.cfg.capture:
                     save_c = c if forward else (self.cfg.cols - 1 - c)
                     self.writer.save_tile(img, r, save_c)
 

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -460,6 +460,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.rast_y2_spin = QtWidgets.QDoubleSpinBox(); self.rast_y2_spin.setDecimals(3); self.rast_y2_spin.setRange(-1000.0, 1000.0); self.rast_y2_spin.setValue(4.0)
         self.btn_raster_p1 = QtWidgets.QPushButton("Raster Point 1")
         self.btn_raster_p2 = QtWidgets.QPushButton("Raster Point 2")
+        self.chk_raster_capture = QtWidgets.QCheckBox("Capture images")
+        self.chk_raster_capture.setChecked(True)
+        self.chk_raster_af = QtWidgets.QCheckBox("Autofocus before capture")
         self.btn_run_raster = QtWidgets.QPushButton("Run Raster")
         r.addWidget(QtWidgets.QLabel("Rows:"), 0, 0); r.addWidget(self.rows_spin, 0, 1)
         r.addWidget(QtWidgets.QLabel("Cols:"), 1, 0); r.addWidget(self.cols_spin, 1, 1)
@@ -469,7 +472,9 @@ class MainWindow(QtWidgets.QMainWindow):
         r.addWidget(QtWidgets.QLabel("X2 (mm):"), 5, 0); r.addWidget(self.rast_x2_spin, 5, 1)
         r.addWidget(QtWidgets.QLabel("Y2 (mm):"), 6, 0); r.addWidget(self.rast_y2_spin, 6, 1)
         r.addWidget(self.btn_raster_p2, 7, 0, 1, 2)
-        r.addWidget(self.btn_run_raster, 8, 0, 1, 2)
+        r.addWidget(self.chk_raster_capture, 8, 0, 1, 2)
+        r.addWidget(self.chk_raster_af, 9, 0, 1, 2)
+        r.addWidget(self.btn_run_raster, 10, 0, 1, 2)
         rightw.addTab(rast, "Raster")
 
         # ---- Scripts tab (restored)
@@ -1237,6 +1242,8 @@ class MainWindow(QtWidgets.QMainWindow):
             y2_mm=self.rast_y2_spin.value(),
             feed_x_mm_min=self.feedx_spin.value(),
             feed_y_mm_min=self.feedy_spin.value(),
+            autofocus=self.chk_raster_af.isChecked(),
+            capture=self.chk_raster_capture.isChecked(),
         )
 
         def do_raster():


### PR DESCRIPTION
## Summary
- allow raster scans to optionally autofocus and capture images
- add UI controls to toggle autofocus and image capture
- test raster runner for autofocus and capture flags

## Testing
- `pytest` *(fails: libGL.so.1 missing)*
- `pytest microstage_app/tests/test_raster.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae19ccaa0c8324bab00185b9dfec4b