### PR TITLE
Use capture settings for raster saves

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -14,11 +14,25 @@ class RasterConfig:
     feed_y_mm_min: float = 20.0
 
 class RasterRunner:
-    def __init__(self, stage, camera, writer, cfg: RasterConfig):
+    def __init__(
+        self,
+        stage,
+        camera,
+        writer,
+        cfg: RasterConfig,
+        directory=None,
+        base_name="tile",
+        auto_number=False,
+        fmt="tif",
+    ):
         self.stage = stage
         self.camera = camera
         self.writer = writer
         self.cfg = cfg
+        self.directory = directory
+        self.base_name = base_name
+        self.auto_number = auto_number
+        self.fmt = fmt
         self.pitch_x_mm = (
             (cfg.x2_mm - cfg.x1_mm) / (cfg.cols - 1) if cfg.cols > 1 else 0.0
         )
@@ -57,5 +71,12 @@ class RasterRunner:
                 img = self.camera.snap()
                 if img is not None:
                     save_c = c if forward else (self.cfg.cols - 1 - c)
-                    self.writer.save_tile(img, r, save_c)
+                    fname = f"{self.base_name}_r{r:04d}_c{save_c:04d}"
+                    self.writer.save_single(
+                        img,
+                        directory=self.directory,
+                        filename=fname,
+                        auto_number=self.auto_number,
+                        fmt=self.fmt,
+                    )
 

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -18,8 +18,8 @@ class CameraMock:
 class WriterMock:
     def __init__(self):
         self.saved = []
-    def save_tile(self, img, r, c):
-        self.saved.append((img, r, c))
+    def save_single(self, img, directory=None, filename="capture", auto_number=False, fmt="bmp"):
+        self.saved.append((img, directory, filename, auto_number, fmt))
 
 
 def test_raster_serpentine(monkeypatch):
@@ -27,9 +27,16 @@ def test_raster_serpentine(monkeypatch):
     cam = CameraMock()
     writer = WriterMock()
     cfg = RasterConfig(rows=2, cols=3, x1_mm=0.0, y1_mm=0.0, x2_mm=2.0, y2_mm=1.0, serpentine=True)
-    runner = RasterRunner(stage, cam, writer, cfg)
+    runner = RasterRunner(stage, cam, writer, cfg, directory="out", base_name="foo", fmt="bmp")
     runner.run()
-    assert writer.saved == [(1,0,0),(2,0,1),(3,0,2),(4,1,0),(5,1,1),(6,1,2)]
+    assert writer.saved == [
+        (1, "out", "foo_r0000_c0000", False, "bmp"),
+        (2, "out", "foo_r0000_c0001", False, "bmp"),
+        (3, "out", "foo_r0000_c0002", False, "bmp"),
+        (4, "out", "foo_r0001_c0000", False, "bmp"),
+        (5, "out", "foo_r0001_c0001", False, "bmp"),
+        (6, "out", "foo_r0001_c0002", False, "bmp"),
+    ]
     assert stage.moves == [
         (1.0,0.0,0.0),
         (1.0,0.0,0.0),
@@ -44,9 +51,16 @@ def test_raster_no_serpentine(monkeypatch):
     cam = CameraMock()
     writer = WriterMock()
     cfg = RasterConfig(rows=2, cols=3, x1_mm=0.0, y1_mm=0.0, x2_mm=2.0, y2_mm=1.0, serpentine=False)
-    runner = RasterRunner(stage, cam, writer, cfg)
+    runner = RasterRunner(stage, cam, writer, cfg, directory="out", base_name="foo", fmt="bmp")
     runner.run()
-    assert writer.saved == [(1,0,0),(2,0,1),(3,0,2),(4,1,0),(5,1,1),(6,1,2)]
+    assert writer.saved == [
+        (1, "out", "foo_r0000_c0000", False, "bmp"),
+        (2, "out", "foo_r0000_c0001", False, "bmp"),
+        (3, "out", "foo_r0000_c0002", False, "bmp"),
+        (4, "out", "foo_r0001_c0000", False, "bmp"),
+        (5, "out", "foo_r0001_c0001", False, "bmp"),
+        (6, "out", "foo_r0001_c0002", False, "bmp"),
+    ]
     assert stage.moves == [
         (1.0,0.0,0.0),
         (1.0,0.0,0.0),

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1239,8 +1239,44 @@ class MainWindow(QtWidgets.QMainWindow):
             feed_y_mm_min=self.feedy_spin.value(),
         )
 
+        directory = self.capture_dir
+        name = self.capture_name
+        auto_num = self.auto_number
+        fmt = self.capture_format
+
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except OSError as e:
+            log(f"Raster aborted: cannot create directory {directory}: {e}")
+            QtWidgets.QMessageBox.critical(
+                self, "Raster", f"Unable to create directory:\n{directory}\n{e}"
+            )
+            return
+
+        if not name:
+            log("Raster aborted: filename empty")
+            QtWidgets.QMessageBox.critical(self, "Raster", "Filename cannot be empty.")
+            return
+        if re.search(r"[\\/:*?\"<>|]", name):
+            log("Raster aborted: illegal characters in filename")
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Raster",
+                "Filename contains illegal characters (\\ / : * ? \" < > |).",
+            )
+            return
+
         def do_raster():
-            runner = RasterRunner(self.stage, self.camera, self.image_writer, cfg)
+            runner = RasterRunner(
+                self.stage,
+                self.camera,
+                self.image_writer,
+                cfg,
+                directory=directory,
+                base_name=name,
+                auto_number=auto_num,
+                fmt=fmt,
+            )
             runner.run()
             return True
 


### PR DESCRIPTION
## Summary
- Save raster scan images using the capture directory, name, auto-numbering, and format fields
- Validate capture settings before raster runs
- Update raster tests for new file naming

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae1b57760883248a93df91cd2b7cbf