### PR TITLE
Enable selectable stage position text

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -226,6 +226,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stage_status = QtWidgets.QLabel("Stage: —")
         self.stage_status.setTextFormat(QtCore.Qt.PlainText)
         self.stage_pos = QtWidgets.QLabel("Pos: —")
+        self.stage_pos.setTextInteractionFlags(
+            QtCore.Qt.TextSelectableByMouse | QtCore.Qt.TextSelectableByKeyboard
+        )
         self.btn_stage_connect = QtWidgets.QPushButton("Connect Stage")
         self.btn_stage_disconnect = QtWidgets.QPushButton("Disconnect Stage")
         self.cam_status = QtWidgets.QLabel("Camera: —")


### PR DESCRIPTION
## Summary
- Allow stage position label text to be selected and copied via mouse or keyboard

## Testing
- `pytest -q`
- `python - <<'PY'
import os
os.environ['QT_QPA_PLATFORM'] = 'offscreen'
from PySide6 import QtWidgets, QtCore
from microstage_app.ui.main_window import MainWindow
app = QtWidgets.QApplication([])
w = MainWindow()
flags = w.stage_pos.textInteractionFlags()
print('Mouse selectable:', bool(flags & QtCore.Qt.TextSelectableByMouse))
print('Keyboard selectable:', bool(flags & QtCore.Qt.TextSelectableByKeyboard))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aed9dcad64832493fff0da6870b83f