### PR TITLE
Persist UI widget settings

### DIFF
--- a/microstage_app/tests/test_ui_settings_persist.py
+++ b/microstage_app/tests/test_ui_settings_persist.py
@@ -1,0 +1,42 @@
+import os
+
+import pytest
+from PySide6 import QtWidgets
+
+import microstage_app.ui.main_window as mw
+from microstage_app.control.profiles import Profiles
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_ui_settings_persist(monkeypatch, tmp_path, qt_app):
+    monkeypatch.setattr(Profiles, "PATH", str(tmp_path / "profiles.yaml"))
+
+    def fake_init(self, base_dir="runs"):
+        self.base_dir = base_dir
+        self.run_dir = str(tmp_path / "runs")
+
+    monkeypatch.setattr(mw.ImageWriter, "__init__", fake_init)
+
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    win1 = mw.MainWindow()
+    win1.stepx_spin.setValue(1.234)
+    win1.feedy_spin.setValue(45.6)
+    win1.absz_spin.setValue(7.89)
+    qt_app.processEvents()
+    win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
+
+    win2 = mw.MainWindow()
+    assert win2.stepx_spin.value() == pytest.approx(1.234)
+    assert win2.feedy_spin.value() == pytest.approx(45.6)
+    assert win2.absz_spin.value() == pytest.approx(7.89)
+    win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()
+


### PR DESCRIPTION
## Summary
- Persist values of jog and absolute move spin boxes via Profiles
- Restore those UI values on startup and save on close
- Test that non-capture widget settings persist between sessions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedaf81d188324a785e455dfd490f4