### PR TITLE
Persist jog fields with test

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -15,6 +15,12 @@ DEFAULTS = {
     },
     # persistent capture settings
     'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'bmp'},
+    # jog UI persistence
+    'jog': {
+        'step': {'x': 0.1, 'y': 0.1, 'z': 0.1},
+        'feed': {'x': 50.0, 'y': 50.0, 'z': 50.0},
+        'abs': {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    },
 }
 
 class Profiles:

--- a/microstage_app/tests/test_ui_field_persistence.py
+++ b/microstage_app/tests/test_ui_field_persistence.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+from PySide6 import QtWidgets
+
+import microstage_app.ui.main_window as mw
+from microstage_app.control.profiles import Profiles
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_ui_field_persistence(monkeypatch, tmp_path, qt_app):
+    monkeypatch.setattr(Profiles, "PATH", str(tmp_path / "profiles.yaml"))
+
+    def fake_init(self, base_dir='runs'):
+        self.base_dir = base_dir
+        self.run_dir = str(tmp_path / "runs")
+    monkeypatch.setattr(mw.ImageWriter, "__init__", fake_init)
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    win1 = mw.MainWindow()
+    win1.stepx_spin.setValue(1.234)
+    win1.feedy_spin.setValue(123.0)
+    win1.absz_spin.setValue(9.876)
+    qt_app.processEvents()
+    win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
+
+    win2 = mw.MainWindow()
+    assert win2.stepx_spin.value() == pytest.approx(1.234)
+    assert win2.feedy_spin.value() == pytest.approx(123.0)
+    assert win2.absz_spin.value() == pytest.approx(9.876)
+    win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()
+

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -197,6 +197,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # UI
         self._build_ui()
         self._connect_signals()
+        self._init_persistent_fields()
 
         # mirror logs to the in-app log pane
         LOG.message.connect(self._append_log)
@@ -578,6 +579,15 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # scripts
         self.btn_run_example_script.clicked.connect(self._run_example_script)
+
+    def _init_persistent_fields(self):
+        def bind(spin, key):
+            spin.setValue(self.profiles.get(key, spin.value()))
+            spin.valueChanged.connect(lambda v, k=key: (self.profiles.set(k, float(v)), self.profiles.save()))
+        for axis in ('x', 'y', 'z'):
+            bind(getattr(self, f'step{axis}_spin'), f'jog.step.{axis}')
+            bind(getattr(self, f'feed{axis}_spin'), f'jog.feed.{axis}')
+            bind(getattr(self, f'abs{axis}_spin'), f'jog.abs.{axis}')
 
     def _on_capture_dir_changed(self, text: str):
         self.capture_dir = text


### PR DESCRIPTION
## Summary
- persist jog step/feed/abs spinbox values via Profiles
- test MainWindow field persistence across sessions

## Testing
- `pytest microstage_app/tests/test_ui_field_persistence.py -q`
- `pytest microstage_app/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68aedcbb588c83249b65ac8f112dd819