### PR TITLE
Refresh stage position indicator after raster completes

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1328,7 +1328,14 @@ class MainWindow(QtWidgets.QMainWindow):
         log("Raster: starting")
         t, w = run_async(do_raster)
         self._last_thread, self._last_worker = t, w
-        w.finished.connect(lambda res, err: log("Raster: done" if not err else f"Raster error: {err}"))
+        w.finished.connect(
+            lambda *_: self.stage_worker.enqueue(
+                self.stage.get_position, callback=self._on_stage_position
+            )
+        )
+        w.finished.connect(
+            lambda res, err: log("Raster: done" if not err else f"Raster error: {err}")
+        )
 
     def _run_example_script(self):
         if not (self.stage and self.camera):


### PR DESCRIPTION
## Summary
- Update raster execution to refresh the stage position indicator once the raster finishes

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aede68aca48324bd52107b36dd207c