### PR TITLE
Add profile schema versioning and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Example usage:
 
 The application stores user preferences and scan presets in a YAML file named
 `profiles.yaml` located in the application's working directory (alongside
-`main.py` when running from source or the packaged executable).
+`main.py` when running from source or the packaged executable). The file also
+contains a `version` field so that older profiles can be migrated
+automatically when new settings are introduced.
 
 Saved fields include:
 

--- a/microstage_app/tests/test_profiles_migration.py
+++ b/microstage_app/tests/test_profiles_migration.py
@@ -1,0 +1,16 @@
+import yaml
+from microstage_app.control.profiles import Profiles, DEFAULTS
+
+
+def test_profiles_migration(monkeypatch, tmp_path):
+    old = {'camera': {'gain': 2.0}}
+    pfile = tmp_path / 'profiles.yaml'
+    pfile.write_text(yaml.safe_dump(old))
+    monkeypatch.setattr(Profiles, 'PATH', str(pfile))
+    p = Profiles.load_or_create()
+    assert p.data['version'] == Profiles.VERSION
+    assert p.data['camera']['gain'] == 2.0
+    assert p.data['camera']['exposure_ms'] == DEFAULTS['camera']['exposure_ms']
+    saved = yaml.safe_load(pfile.read_text())
+    assert saved['version'] == Profiles.VERSION
+    assert 'capture' in saved


### PR DESCRIPTION
## Summary
- add `version` field to profile defaults and track latest schema version
- implement `Profiles.migrate()` to update old profile files and fill missing keys
- document profile versioning and add tests for migration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee4ebe6ac8324ada6de46f177a5f3