### PR TITLE
Sequence autofocus and capture steps with delays

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -102,19 +102,25 @@ class RasterRunner:
                     self.position_cb(pos)
                 time.sleep(0.03)
 
-                if self.cfg.autofocus and AutoFocus:
+                do_af = bool(self.cfg.autofocus and AutoFocus)
+                do_capture = bool(self.cfg.capture)
+
+                if do_af:
                     af = AutoFocus(self.stage, self.camera)
                     af.coarse_to_fine(metric=FocusMetric.LAPLACIAN)
+                    time.sleep(1)
 
-                img = self.camera.snap() if self.cfg.capture else None
-                if img is not None and self.cfg.capture:
-                    save_c = c if forward else (self.cfg.cols - 1 - c)
-                    fname = f"{self.base_name}_r{r:04d}_c{save_c:04d}"
-                    self.writer.save_single(
-                        img,
-                        directory=self.directory,
-                        filename=fname,
-                        auto_number=self.auto_number,
-                        fmt=self.fmt,
-                    )
+                if do_capture:
+                    img = self.camera.snap()
+                    if img is not None:
+                        save_c = c if forward else (self.cfg.cols - 1 - c)
+                        fname = f"{self.base_name}_r{r:04d}_c{save_c:04d}"
+                        self.writer.save_single(
+                            img,
+                            directory=self.directory,
+                            filename=fname,
+                            auto_number=self.auto_number,
+                            fmt=self.fmt,
+                        )
+                    time.sleep(1)
 


### PR DESCRIPTION
## Summary
- Ensure `RasterRunner` decides at each stop if autofocus and/or capture are active, running autofocus before capture with a one-second pause after each
- Add comprehensive test verifying operation order and sleep delays for autofocus-only, capture-only, and combined scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee70e71b88324969a769172858bc1