### PR TITLE
Ensure serpentine raster naming reflects actual column index

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -113,7 +113,7 @@ class RasterRunner:
                 if do_capture:
                     img = self.camera.snap()
                     if img is not None:
-                        save_c = c if forward else (self.cfg.cols - 1 - c)
+                        save_c = c
                         fname = f"{self.base_name}_r{r:04d}_c{save_c:04d}"
                         self.writer.save_single(
                             img,

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -50,9 +50,9 @@ def test_raster_serpentine(monkeypatch):
         (1, "out", "foo_r0000_c0000", False, "bmp"),
         (2, "out", "foo_r0000_c0001", False, "bmp"),
         (3, "out", "foo_r0000_c0002", False, "bmp"),
-        (4, "out", "foo_r0001_c0000", False, "bmp"),
+        (4, "out", "foo_r0001_c0002", False, "bmp"),
         (5, "out", "foo_r0001_c0001", False, "bmp"),
-        (6, "out", "foo_r0001_c0002", False, "bmp"),
+        (6, "out", "foo_r0001_c0000", False, "bmp"),
     ]
     assert stage.moves == [
         (1.0,0.0,0.0),


### PR DESCRIPTION
## Summary
- Use actual column index when naming tiles in serpentine raster scans
- Update tests to expect reversed column numbers on odd rows

## Testing
- `pytest microstage_app/tests/test_raster.py`

------
https://chatgpt.com/codex/tasks/task_e_68aef6459e4883248b23bcacd3fff40d