### PR TITLE
Persist camera settings

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -4,7 +4,21 @@ from ..utils.log import log
 DEFAULTS = {
     'version': 1,
     'stage': {'feed_mm_s': 50.0 / 60.0, 'settle_ms': 30},
-    'camera': {'exposure_ms': 10.0, 'gain': 1.0, 'binning': 1},
+    'camera': {
+        'exposure_ms': 10.0,
+        'auto_exposure': False,
+        'gain': 100,
+        'brightness': 0,
+        'contrast': 0,
+        'saturation': 128,
+        'hue': 0,
+        'gamma': 100,
+        'raw': False,
+        'binning': 1,
+        'resolution_index': 0,
+        'speed_level': 0,
+        'display_decimation': 1,
+    },
     'scan_presets': {
         'raster': {
             'x1_mm': 0.0,

--- a/tests/test_camera_settings_persist.py
+++ b/tests/test_camera_settings_persist.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from PySide6 import QtWidgets
+
+# Ensure repository root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from microstage_app.ui.main_window import MainWindow
+from microstage_app.control.profiles import Profiles
+
+
+def test_camera_settings_persist(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    profile_path = tmp_path / "profiles.yaml"
+    orig_path = Profiles.PATH
+    Profiles.PATH = str(profile_path)
+    if profile_path.exists():
+        profile_path.unlink()
+
+    MainWindow._auto_connect_async = lambda self: None
+
+    w = MainWindow()
+    w.exp_spin.setValue(20.0)
+    w.autoexp_chk.setChecked(True)
+    w.gain_spin.setValue(150)
+    w.brightness_spin.setValue(40)
+    w.contrast_spin.setValue(-10)
+    w.saturation_spin.setValue(200)
+    w.hue_spin.setValue(5)
+    w.gamma_spin.setValue(70)
+    w.raw_chk.setChecked(True)
+    w.speed_spin.setValue(2)
+    w.decim_spin.setValue(3)
+    w.close()
+
+    w2 = MainWindow()
+    assert w2.exp_spin.value() == 20.0
+    assert w2.autoexp_chk.isChecked() is True
+    assert w2.gain_spin.value() == 150
+    assert w2.brightness_spin.value() == 40
+    assert w2.contrast_spin.value() == -10
+    assert w2.saturation_spin.value() == 200
+    assert w2.hue_spin.value() == 5
+    assert w2.gamma_spin.value() == 70
+    assert w2.raw_chk.isChecked() is True
+    assert w2.speed_spin.value() == 2
+    assert w2.decim_spin.value() == 3
+    w2.close()
+    Profiles.PATH = orig_path


### PR DESCRIPTION
## Summary
- add extensive camera defaults including exposure, gain, brightness, and more
- persist camera control widgets and apply saved profiles on connect
- cover camera setting persistence with a new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aefae7734c8324a8e83ab2dd3b4159