### PR TITLE
Add focus stacking capture feature

### DIFF
--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -1,8 +1,12 @@
 from enum import Enum
 import math
+import os
 import numpy as np
 import cv2
 import time
+from typing import Optional
+
+from ..io.storage import ImageWriter
 
 class FocusMetric(str, Enum):
     LAPLACIAN = "LaplacianVar"
@@ -86,3 +90,83 @@ class AutoFocus:
         )
         self.stage.wait_for_moves()
         return best_fine_dz
+
+    def focus_stack(
+        self,
+        range_mm: float,
+        step_mm: float,
+        writer: ImageWriter,
+        *,
+        directory: Optional[str] = None,
+        metric: Optional[FocusMetric] = None,
+        feed_mm_per_min: float = 240,
+        fmt: str = "bmp",
+    ) -> Optional[int]:
+        """Sweep Z over ``range_mm`` in ``step_mm`` increments and capture frames.
+
+        Parameters
+        ----------
+        range_mm : float
+            Total sweep range in millimeters. The stage will move equally in
+            positive and negative directions around the starting position.
+        step_mm : float
+            Step size in millimeters for each captured frame.
+        writer : ImageWriter
+            Destination image writer used to save the stack.
+        directory : str, optional
+            Directory in which to save images. If ``None``, ``writer.run_dir``
+            is used.
+        metric : FocusMetric, optional
+            If provided, compute the metric for each frame and return the index
+            of the sharpest frame.
+        feed_mm_per_min : float
+            Feed rate for Z movement.
+        fmt : str
+            Image format passed to :meth:`ImageWriter.save_single`.
+
+        Returns
+        -------
+        Optional[int]
+            Index of the frame with highest focus metric, if ``metric`` is
+            provided; otherwise ``None``.
+        """
+
+        if step_mm <= 0:
+            raise ValueError("step_mm must be > 0")
+
+        directory = directory or writer.run_dir
+        os.makedirs(directory, exist_ok=True)
+
+        steps = int(max(1, round(range_mm / step_mm)))
+        zs = [(-steps + i) * step_mm for i in range(2 * steps + 1)]
+        cumulative = 0.0
+        metrics = []
+        for i, dz in enumerate(zs):
+            move = dz - cumulative
+            self.stage.move_relative(dz=move, feed_mm_per_min=feed_mm_per_min)
+            self.stage.wait_for_moves()
+            time.sleep(0.02)
+            img = self.camera.snap()
+            if img is None:
+                if metric:
+                    metrics.append(float("-inf"))
+                continue
+            writer.save_single(
+                img,
+                directory=directory,
+                filename=f"{i:04d}",
+                auto_number=False,
+                fmt=fmt,
+            )
+            if metric:
+                metrics.append(metric_value(img, metric))
+            cumulative = dz
+
+        # Return to starting position
+        self.stage.move_relative(dz=-cumulative, feed_mm_per_min=feed_mm_per_min)
+        self.stage.wait_for_moves()
+
+        if metric and metrics:
+            best_idx = int(np.argmax(metrics))
+            return best_idx
+        return None


### PR DESCRIPTION
## Summary
- add focus_stack method to AutoFocus for Z sweep imaging and optional metric
- add Focus Stack controls to UI and integrate saving to subfolder via ImageWriter

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0569edb083249a2800da8375a51d