### PR TITLE
Add leveling routine with surface fitting

### DIFF
--- a/microstage_app/control/leveling.py
+++ b/microstage_app/control/leveling.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Sequence, Tuple, List
+
+try:
+    from .autofocus import AutoFocus, FocusMetric
+except Exception:  # pragma: no cover - autofocus dependencies might be missing
+    AutoFocus = None  # type: ignore
+    FocusMetric = None  # type: ignore
+
+from .focus_planes import SurfaceModel, SurfaceKind
+
+
+class LevelingMode(str, Enum):
+    """Available surface fitting modes for leveling."""
+
+    LINEAR = "linear"
+    QUADRATIC = "quadratic"
+    CUBIC = "cubic"
+
+
+def three_point_level(
+    stage,
+    camera,
+    points: Sequence[Tuple[float, float]],
+    mode: LevelingMode = LevelingMode.LINEAR,
+) -> SurfaceModel:
+    """Fit a focus surface from measurements at multiple XY points.
+
+    Parameters
+    ----------
+    stage : Stage-like object
+        Object providing ``move_absolute``, ``wait_for_moves`` and
+        ``get_position`` methods.
+    camera : camera-like object
+        Used with :class:`AutoFocus` when available.
+    points : Sequence[Tuple[float, float]]
+        XY coordinates in millimetres to probe.
+    mode : LevelingMode
+        Surface fitting model to use.
+
+    Returns
+    -------
+    SurfaceModel
+        Fitted surface model for the measured points.
+
+    Raises
+    ------
+    ValueError
+        If insufficient points are supplied for the requested ``mode``.
+    """
+
+    required = {
+        LevelingMode.LINEAR: 3,
+        LevelingMode.QUADRATIC: 6,
+        LevelingMode.CUBIC: 10,
+    }
+    n = len(points)
+    if n < required[mode]:
+        raise ValueError(
+            f"{mode.value} leveling requires at least {required[mode]} points, got {n}"
+        )
+
+    samples: List[Tuple[float, float, float]] = []
+    for x, y in points:
+        stage.move_absolute(x=x, y=y)
+        stage.wait_for_moves()
+
+        if AutoFocus and camera is not None:  # pragma: no branch
+            try:
+                af = AutoFocus(stage, camera)
+                af.coarse_to_fine(metric=FocusMetric.LAPLACIAN)
+                stage.wait_for_moves()
+            except Exception:
+                pass
+
+        pos = stage.get_position()
+        if pos is None or len(pos) < 3:
+            raise RuntimeError("stage did not return a valid position")
+        z = float(pos[2])
+        samples.append((x, y, z))
+
+    model = SurfaceModel(kind=SurfaceKind(mode.value))
+    model.fit(samples)
+    return model

--- a/microstage_app/tests/test_leveling.py
+++ b/microstage_app/tests/test_leveling.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+
+from microstage_app.control.leveling import three_point_level, LevelingMode
+
+
+class DummyStage:
+    def __init__(self, surface):
+        self.x = 0.0
+        self.y = 0.0
+        self.z = 0.0
+        self.surface = surface
+
+    def move_absolute(self, x=None, y=None, z=None, feed_mm_per_min=0.0):
+        if x is not None:
+            self.x = x
+        if y is not None:
+            self.y = y
+        if z is not None:
+            self.z = z
+
+    def wait_for_moves(self):
+        pass
+
+    def get_position(self):
+        self.z = self.surface(self.x, self.y)
+        return (self.x, self.y, self.z)
+
+
+class DummyCamera:
+    def snap(self):  # pragma: no cover - not used
+        return None
+
+
+def test_three_point_level_linear(monkeypatch):
+    # Disable autofocus
+    import microstage_app.control.leveling as leveling
+    monkeypatch.setattr(leveling, "AutoFocus", None)
+
+    def plane(x, y):
+        return x + 2 * y
+
+    stage = DummyStage(plane)
+    cam = DummyCamera()
+    pts = [(0, 0), (1, 0), (0, 1)]
+    model = three_point_level(stage, cam, pts, LevelingMode.LINEAR)
+    assert np.isclose(model.predict(2, 3), plane(2, 3))
+
+
+def test_three_point_level_insufficient_points(monkeypatch):
+    import microstage_app.control.leveling as leveling
+    monkeypatch.setattr(leveling, "AutoFocus", None)
+
+    stage = DummyStage(lambda x, y: 0)
+    cam = DummyCamera()
+
+    for mode, required in [
+        (LevelingMode.LINEAR, 3),
+        (LevelingMode.QUADRATIC, 6),
+        (LevelingMode.CUBIC, 10),
+    ]:
+        pts = [(0, 0)] * (required - 1)
+        with pytest.raises(ValueError) as exc:
+            three_point_level(stage, cam, pts, mode)
+        assert str(required) in str(exc.value)


### PR DESCRIPTION
## Summary
- add `LevelingMode` enum and `three_point_level` to measure focus at points and fit a polynomial surface
- test surface fitting and point-count validation

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*
- `pytest microstage_app/tests/test_leveling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af3b5374448324a2f43ddc0206318f