### PR TITLE
Add leveling and SurfaceModel tests

### DIFF
--- a/microstage_app/tests/test_leveling.py
+++ b/microstage_app/tests/test_leveling.py
@@ -36,6 +36,31 @@ class DummyCamera:
         return None
 
 
+class ManualStage:
+    def __init__(self, surface):
+        self.x = 0.0
+        self.y = 0.0
+        self.z = 0.0
+        self.surface = surface
+        self.positions = []
+
+    def move_absolute(self, x=None, y=None, z=None, feed_mm_per_min=0.0):
+        if x is not None:
+            self.x = x
+        if y is not None:
+            self.y = y
+        if z is not None:
+            self.z = z
+
+    def wait_for_moves(self):
+        pass
+
+    def get_position(self):
+        pos = (self.x, self.y, self.z)
+        self.positions.append(pos)
+        return pos
+
+
 def test_three_point_level_linear(monkeypatch):
     # Disable autofocus
     import microstage_app.control.leveling as leveling
@@ -48,6 +73,31 @@ def test_three_point_level_linear(monkeypatch):
     cam = DummyCamera()
     pts = [(0, 0), (1, 0), (0, 1)]
     model = three_point_level(stage, cam, pts, LevelingMode.LINEAR)
+    assert np.isclose(model.predict(2, 3), plane(2, 3))
+
+
+def test_three_point_level_autofocus_called(monkeypatch):
+    import microstage_app.control.leveling as leveling
+
+    class DummyAF:
+        calls = 0
+
+        def __init__(self, stage, camera):
+            DummyAF.calls += 1
+
+        def coarse_to_fine(self, metric=None):
+            pass
+
+    monkeypatch.setattr(leveling, "AutoFocus", DummyAF)
+
+    def plane(x, y):
+        return x + 2 * y
+
+    stage = DummyStage(plane)
+    cam = DummyCamera()
+    pts = [(0, 0), (1, 0), (0, 1)]
+    model = three_point_level(stage, cam, pts, LevelingMode.LINEAR)
+    assert DummyAF.calls == len(pts)
     assert np.isclose(model.predict(2, 3), plane(2, 3))
 
 
@@ -71,7 +121,17 @@ def test_three_point_level_insufficient_points(monkeypatch):
 
 def test_grid_level_linear_autofocus(monkeypatch):
     import microstage_app.control.leveling as leveling
-    monkeypatch.setattr(leveling, "AutoFocus", None)
+
+    class DummyAF:
+        calls = 0
+
+        def __init__(self, stage, camera):
+            DummyAF.calls += 1
+
+        def coarse_to_fine(self, metric=None):
+            pass
+
+    monkeypatch.setattr(leveling, "AutoFocus", DummyAF)
 
     def plane(x, y):
         return x + 2 * y
@@ -80,21 +140,46 @@ def test_grid_level_linear_autofocus(monkeypatch):
     cam = DummyCamera()
     rect = (0.0, 0.0, 1.0, 1.0)
     model = grid_level(stage, cam, rect, rows=2, cols=2, mode=LevelingMode.LINEAR)
+    assert DummyAF.calls == 4
     assert np.isclose(model.predict(2, 3), plane(2, 3))
 
 
-def test_grid_level_manual(monkeypatch):
+def test_grid_level_manual_records_z(monkeypatch):
     import microstage_app.control.leveling as leveling
-    monkeypatch.setattr(leveling, "AutoFocus", None)
-    monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
+
+    class DummyAF:
+        calls = 0
+
+        def __init__(self, stage, camera):
+            DummyAF.calls += 1
+
+        def coarse_to_fine(self, metric=None):
+            pass
+
+    monkeypatch.setattr(leveling, "AutoFocus", DummyAF)
 
     def plane(x, y):
         return x + 2 * y
 
-    stage = DummyStage(plane)
+    stage = ManualStage(plane)
     cam = DummyCamera()
+
+    def focus_prompt(*args, **kwargs):
+        stage.z = plane(stage.x, stage.y)
+        return ""
+
+    monkeypatch.setattr("builtins.input", focus_prompt)
+
     rect = (0.0, 0.0, 1.0, 1.0)
     model = grid_level(
         stage, cam, rect, rows=2, cols=2, mode=LevelingMode.LINEAR, autofocus=False
     )
+    assert DummyAF.calls == 0
+    expected = [
+        (0.0, 0.0, plane(0, 0)),
+        (1.0, 0.0, plane(1, 0)),
+        (0.0, 1.0, plane(0, 1)),
+        (1.0, 1.0, plane(1, 1)),
+    ]
+    assert np.allclose(stage.positions, expected)
     assert np.isclose(model.predict(2, 3), plane(2, 3))

--- a/microstage_app/tests/test_surface_model.py
+++ b/microstage_app/tests/test_surface_model.py
@@ -42,3 +42,63 @@ def test_surface_model_cubic():
     expected = (-2) ** 3 + 3 ** 3
     assert np.isclose(m.predict(-2, 3), expected)
 
+
+def test_surface_model_linear_coefficients():
+    a, b, c = 1.5, -2.0, 0.5
+    coords = [(0, 0), (1, 0), (0, 1), (2, -1), (-1, 2)]
+    pts = [(x, y, a + b * x + c * y) for x, y in coords]
+    m = SurfaceModel(kind=SurfaceKind.LINEAR)
+    m.fit(pts)
+    assert np.allclose(m.coeffs, [a, b, c])
+
+
+def test_surface_model_quadratic_coefficients():
+    a, b, c, d, e, f = 1, 2, 3, 4, 5, 6
+    coords = [
+        (-1, -1),
+        (-1, 0),
+        (-1, 1),
+        (0, -1),
+        (0, 0),
+        (0, 1),
+        (1, -1),
+        (1, 0),
+        (1, 1),
+    ]
+    pts = [
+        (
+            x,
+            y,
+            a + b * x + c * y + d * x ** 2 + e * x * y + f * y ** 2,
+        )
+        for x, y in coords
+    ]
+    m = SurfaceModel(kind=SurfaceKind.QUADRATIC)
+    m.fit(pts)
+    assert np.allclose(m.coeffs, [a, b, c, d, e, f])
+
+
+def test_surface_model_cubic_coefficients():
+    a, b, c, d, e, f, g, h, i, j = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+    coords = [(x, y) for x in (-1, 0, 1, 2) for y in (-1, 0, 1, 2)]
+    pts = [
+        (
+            x,
+            y,
+            a
+            + b * x
+            + c * y
+            + d * x ** 2
+            + e * x * y
+            + f * y ** 2
+            + g * x ** 3
+            + h * (x ** 2) * y
+            + i * x * (y ** 2)
+            + j * y ** 3,
+        )
+        for x, y in coords
+    ]
+    m = SurfaceModel(kind=SurfaceKind.CUBIC)
+    m.fit(pts)
+    assert np.allclose(m.coeffs, [a, b, c, d, e, f, g, h, i, j])
+


### PR DESCRIPTION
## Summary
- verify SurfaceModel correctly estimates coefficients for linear, quadratic, and cubic surfaces
- ensure three_point_level and grid_level invoke AutoFocus in automatic mode
- confirm grid_level manual mode records user-provided Z values and fits surface correctly

## Testing
- `pytest microstage_app/tests/test_surface_model.py microstage_app/tests/test_leveling.py`


------
https://chatgpt.com/codex/tasks/task_e_68af3e5774588324ae150121ab810a41