### PR TITLE
Increase stage move precision to six decimals

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -135,18 +135,18 @@ class StageMarlin:
     def move_relative(self, dx=0, dy=0, dz=0, feed_mm_per_min=600, wait_ok=False):
         self.relative_mode()
         parts = ["G1"]
-        if dx: parts.append(f"X{dx:.4f}")
-        if dy: parts.append(f"Y{dy:.4f}")
-        if dz: parts.append(f"Z{dz:.4f}")
+        if dx: parts.append(f"X{dx:.6f}")
+        if dy: parts.append(f"Y{dy:.6f}")
+        if dz: parts.append(f"Z{dz:.6f}")
         parts.append(f"F{feed_mm_per_min:.2f}")
         self.send(" ".join(parts), wait_ok=wait_ok)
         self.absolute_mode()
 
     def move_absolute(self, x=None, y=None, z=None, feed_mm_per_min=600, wait_ok=False):
         parts = ["G1"]
-        if x is not None: parts.append(f"X{x:.4f}")
-        if y is not None: parts.append(f"Y{y:.4f}")
-        if z is not None: parts.append(f"Z{z:.4f}")
+        if x is not None: parts.append(f"X{x:.6f}")
+        if y is not None: parts.append(f"Y{y:.6f}")
+        if z is not None: parts.append(f"Z{z:.6f}")
         parts.append(f"F{feed_mm_per_min:.2f}")
         self.send("G90", wait_ok=True)
         self.send(" ".join(parts), wait_ok=wait_ok)

--- a/microstage_app/tests/test_stage_driver.py
+++ b/microstage_app/tests/test_stage_driver.py
@@ -22,10 +22,10 @@ def test_move_commands(monkeypatch):
     stage.move_relative(dx=1.0, dy=-2.0, dz=0.5, feed_mm_per_min=123, wait_ok=True)
     assert dummy.writes[0].strip() == 'G91'
     cmd = dummy.writes[1]
-    assert 'X1.0000' in cmd and 'Y-2.0000' in cmd and 'Z0.5000' in cmd and 'F123.00' in cmd
+    assert 'X1.000000' in cmd and 'Y-2.000000' in cmd and 'Z0.500000' in cmd and 'F123.00' in cmd
     assert dummy.writes[2].strip() == 'G90'
     dummy.writes.clear()
     stage.move_absolute(x=2.0, z=-1.0, feed_mm_per_min=150, wait_ok=True)
     assert dummy.writes[0].strip() == 'G90'
     cmd = dummy.writes[1]
-    assert cmd.startswith('G1') and 'X2.0000' in cmd and 'Z-1.0000' in cmd and 'F150.00' in cmd
+    assert cmd.startswith('G1') and 'X2.000000' in cmd and 'Z-1.000000' in cmd and 'F150.00' in cmd


### PR DESCRIPTION
## Summary
- expand Marlin stage move commands to use six decimal precision for X/Y/Z
- update unit test expectations for new precision

## Testing
- `pytest microstage_app/tests/test_stage_driver.py -q`
- `pytest microstage_app/tests/test_af_spinbox_decimals.py -q` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af5ba92ff883248d4d753502e16358