### PR TITLE
Increase stage position precision

### DIFF
--- a/microstage_app/tests/test_dispatch_stage_result.py
+++ b/microstage_app/tests/test_dispatch_stage_result.py
@@ -23,7 +23,7 @@ def test_dispatch_updates_stage_pos(monkeypatch, qt_app):
         pos = (1.0, 2.0, 3.0)
         win._dispatch_stage_result(win._on_stage_position, pos)
         QtWidgets.QApplication.processEvents()
-        assert "X1.000" in win.stage_pos.text()
+        assert "X1.000000" in win.stage_pos.text()
     finally:
         win.preview_timer.stop()
         win.fps_timer.stop()
@@ -42,7 +42,7 @@ def test_dispatch_partial_pos(monkeypatch, qt_app):
         win._dispatch_stage_result(win._on_stage_position, (None, None, 4.0))
         QtWidgets.QApplication.processEvents()
         txt = win.stage_pos.text()
-        assert "X1.000" in txt and "Y2.000" in txt and "Z4.000" in txt
+        assert "X1.000000" in txt and "Y2.000000" in txt and "Z4.000000" in txt
     finally:
         win.preview_timer.stop()
         win.fps_timer.stop()

--- a/microstage_app/tests/test_stage_marlin_get_position.py
+++ b/microstage_app/tests/test_stage_marlin_get_position.py
@@ -42,10 +42,10 @@ def test_get_position_and_label(monkeypatch, qt_app):
     try:
         win._on_stage_position((0.0, 0.0, z1))
         QtWidgets.QApplication.processEvents()
-        assert "Z1.000" in win.stage_pos.text()
+        assert "Z1.000000" in win.stage_pos.text()
         win._on_stage_position((0.0, 0.0, z2))
         QtWidgets.QApplication.processEvents()
-        assert "Z2.000" in win.stage_pos.text()
+        assert "Z2.000000" in win.stage_pos.text()
     finally:
         win.preview_timer.stop()
         win.fps_timer.stop()

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1164,7 +1164,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # then the limits. This ensures the limits line never precedes the
         # coordinates, even if the stage bounds are unavailable.
         def _fmt(v):
-            return f"{v:.3f}" if v is not None else "—"
+            return f"{v:.6f}" if v is not None else "—"
         coords_line = (
             f"Pos: X{_fmt(self._last_pos['x'])} "
             f"Y{_fmt(self._last_pos['y'])} "
@@ -1173,9 +1173,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.stage_bounds:
             b = self.stage_bounds
             limits_line = (
-                f"Limits: X[{b['xmin']:.3f},{b['xmax']:.3f}] "
-                f"Y[{b['ymin']:.3f},{b['ymax']:.3f}] "
-                f"Z[{b['zmin']:.3f},{b['zmax']:.3f}]"
+                f"Limits: X[{b['xmin']:.6f},{b['xmax']:.6f}] "
+                f"Y[{b['ymin']:.6f},{b['ymax']:.6f}] "
+                f"Z[{b['zmin']:.6f},{b['zmax']:.6f}]"
             )
         else:
             limits_line = "Limits: —"


### PR DESCRIPTION
## Summary
- Display stage coordinates and bounds with six decimal places
- Adjust UI tests for expanded coordinate precision

## Testing
- `pytest microstage_app/tests/test_dispatch_stage_result.py microstage_app/tests/test_stage_marlin_get_position.py -q`
- `pytest -q` *(fails: test_af_spinbox_decimals expected rounded value)*

------
https://chatgpt.com/codex/tasks/task_e_68af5e52739483249221223fa25f2b3c