### PR TITLE
Assert six-decimal stage and autofocus formatting

### DIFF
--- a/microstage_app/tests/test_af_spinbox_decimals.py
+++ b/microstage_app/tests/test_af_spinbox_decimals.py
@@ -34,9 +34,8 @@ def test_af_spinboxes_six_decimals(monkeypatch, qt_app):
         QtTest.QTest.keyClicks(line, "0.1234567")
         QtTest.QTest.keyClick(line, QtCore.Qt.Key_Return)
         qt_app.processEvents()
-        # Value should be displayed with six decimal places and roughly match the input
-        assert float(box.text()) == pytest.approx(0.1234567, abs=1e-6)
-        assert len(box.text().split(".")[1]) == 6
+        # The displayed value should round to six decimal places.
+        assert box.text() == "0.123457"
 
         box.setValue(0.0015)
         qt_app.processEvents()

--- a/microstage_app/tests/test_dispatch_stage_result.py
+++ b/microstage_app/tests/test_dispatch_stage_result.py
@@ -23,7 +23,8 @@ def test_dispatch_updates_stage_pos(monkeypatch, qt_app):
         pos = (1.0, 2.0, 3.0)
         win._dispatch_stage_result(win._on_stage_position, pos)
         QtWidgets.QApplication.processEvents()
-        assert "X1.000000" in win.stage_pos.text()
+        txt = win.stage_pos.text()
+        assert "X1.000000" in txt and "Y2.000000" in txt and "Z3.000000" in txt
     finally:
         win.preview_timer.stop()
         win.fps_timer.stop()

--- a/microstage_app/tests/test_stage_marlin_get_position.py
+++ b/microstage_app/tests/test_stage_marlin_get_position.py
@@ -25,14 +25,14 @@ def qt_app():
 
 def test_get_position_and_label(monkeypatch, qt_app):
     responses = [
-        "X:0.00 Y:0.00 Z:1.00 E:0.00 count X:0 Y:0 Z:0",
-        "X:0.00 Y:0.00 Z:2.00 E:0.00 count X:0 Y:0 Z:0",
+        "X:1.00 Y:0.00 Z:1.00 E:0.00 count X:0 Y:0 Z:0",
+        "X:1.00 Y:0.00 Z:2.00 E:0.00 count X:0 Y:0 Z:0",
     ]
     stage = FakeStage(responses)
-    z1 = stage.get_position()[2]
-    assert z1 == 1.0
-    z2 = stage.get_position()[2]
-    assert z2 == 2.0
+    x1, _, z1 = stage.get_position()
+    assert x1 == 1.0 and z1 == 1.0
+    x2, _, z2 = stage.get_position()
+    assert x2 == 1.0 and z2 == 2.0
 
     monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
     monkeypatch.setattr(mw.MainWindow, "_attach_stage_worker", lambda self: None)
@@ -40,12 +40,14 @@ def test_get_position_and_label(monkeypatch, qt_app):
 
     win = mw.MainWindow()
     try:
-        win._on_stage_position((0.0, 0.0, z1))
+        win._on_stage_position((x1, 0.0, z1))
         QtWidgets.QApplication.processEvents()
+        assert "X1.000000" in win.stage_pos.text()
         assert "Z1.000000" in win.stage_pos.text()
-        win._on_stage_position((0.0, 0.0, z2))
+        win._on_stage_position((x1, 0.0, z2))
         QtWidgets.QApplication.processEvents()
-        assert "Z2.000000" in win.stage_pos.text()
+        txt = win.stage_pos.text()
+        assert "X1.000000" in txt and "Z2.000000" in txt
     finally:
         win.preview_timer.stop()
         win.fps_timer.stop()


### PR DESCRIPTION
## Summary
- Verify autofocus spinboxes round and display six decimal places
- Check stage position labels output coordinates with six decimals
- Confirm stage driver emits G-code coordinates formatted to six places

## Testing
- `pytest microstage_app/tests/test_stage_driver.py::test_move_commands -q`
- `pytest microstage_app/tests/test_af_spinbox_decimals.py::test_af_spinboxes_six_decimals -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest microstage_app/tests/test_stage_marlin_get_position.py::test_get_position_and_label -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest microstage_app/tests/test_dispatch_stage_result.py::test_dispatch_updates_stage_pos -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68af606426fc8324a5f0717ef24bfc3c