### PR TITLE
Fix camera USB bandwidth handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -91,7 +91,7 @@ Jog:
 
 Camera:
 - Exposure (ms) (Auto optional), Gain, RAW8 fast mono (8-bit; ~1/3 bandwidth vs RGB24), Resolution index,
-  ROI presets (Full, 2048^2, 1024^2, 512^2), USB speed/bandwidth level, and display decimation (show every Nth frame).
+  ROI presets (Full, 2048^2, 1024^2, 512^2), and display decimation (show every Nth frame). USB bandwidth is fixed to level 5.
 - Smaller ROI / shorter exposure -> higher FPS.
 
 Capture:

--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -16,7 +16,6 @@ DEFAULTS = {
         'raw': False,
         'binning': 1,
         'resolution_index': 0,
-        'speed_level': 0,
         'display_decimation': 1,
     },
     'scan_presets': {

--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -160,25 +160,11 @@ class ToupcamCamera:
             except Exception:
                 log("Camera: USB type unknown")
 
-        # ensure highest bandwidth mode if supported
+        # force maximum bandwidth
         try:
-            if hasattr(self._cam, "get_MaxSpeed"):
-                maxspeed = self._cam.get_MaxSpeed()
-            elif hasattr(self._cam, "MaxSpeed"):
-                maxspeed = self._cam.MaxSpeed()
-            else:
-                maxspeed = None
-
-            if maxspeed is None:
-                log("Camera: speed query not supported")
-                return
-
-            cur = self._cam.get_Speed() if hasattr(self._cam, "get_Speed") else None
-            log(f"Camera: speed levels 0-{maxspeed}, current {cur}")
-            if cur is None or cur < maxspeed:
-                self.set_speed_level(maxspeed)
+            self.set_speed_level(5)
         except Exception as e:
-            log(f"Camera: speed query failed: {e}")
+            log(f"Camera: set speed failed: {e}")
 
     def _query_binning_options(self):
         """Populate supported digital binning factors if available."""
@@ -616,17 +602,18 @@ class ToupcamCamera:
             log(f"Camera: RAW8 fast mono={'ON' if self._raw_mode else 'OFF'}")
 
     def set_speed_level(self, level: int):
-        """Adjust USB bandwidth/speed if the SDK exposes it."""
+        """Force USB bandwidth to level 5 regardless of input."""
+        level = 5
         try:
             # Some SDKs expose put_Speed / get_Speed; others via put_Option
             if hasattr(self._cam, "put_Speed"):
-                self._cam.put_Speed(int(level))
+                self._cam.put_Speed(level)
             elif hasattr(self._tp, "TOUPCAM_OPTION_SPEED"):
-                self._cam.put_Option(self._tp.TOUPCAM_OPTION_SPEED, int(level))
+                self._cam.put_Option(self._tp.TOUPCAM_OPTION_SPEED, level)
             else:
                 log("Camera: speed option not supported")
                 return
-            log(f"Camera: speed level set to {level}")
+            log("Camera: speed level set to 5")
         except Exception as e:
             log(f"Camera: set_speed_level failed: {e}")
 

--- a/tests/test_camera_settings_persist.py
+++ b/tests/test_camera_settings_persist.py
@@ -33,7 +33,6 @@ def test_camera_settings_persist(tmp_path):
     w.hue_spin.setValue(5)
     w.gamma_spin.setValue(70)
     w.raw_chk.setChecked(True)
-    w.speed_spin.setValue(2)
     w.decim_spin.setValue(3)
     w.close()
 
@@ -47,7 +46,6 @@ def test_camera_settings_persist(tmp_path):
     assert w2.hue_spin.value() == 5
     assert w2.gamma_spin.value() == 70
     assert w2.raw_chk.isChecked() is True
-    assert w2.speed_spin.value() == 2
     assert w2.decim_spin.value() == 3
     w2.close()
     Profiles.PATH = orig_path


### PR DESCRIPTION
## Summary
- remove USB speed spin box and persist only necessary camera settings
- always set Toupcam bandwidth to level 5
- drop speed-level profile support and update docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af84c786008324994a34666ac6e1c8