### PR TITLE
Add scale bar overlay to captured images

### DIFF
--- a/microstage_app/tests/test_scale_bar.py
+++ b/microstage_app/tests/test_scale_bar.py
@@ -1,0 +1,60 @@
+import os
+from types import SimpleNamespace
+
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from PySide6 import QtWidgets
+
+import microstage_app.ui.main_window as mw
+from microstage_app.analysis import Lens
+from microstage_app.utils.img import draw_scale_bar
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_draw_scale_bar_basic():
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    out = draw_scale_bar(img, 1.0)
+    assert np.all(out[80, 160:180] == 255)
+
+
+def test_capture_applies_scale_bar(monkeypatch, tmp_path, qt_app):
+    win = mw.MainWindow()
+    win.stage = SimpleNamespace(wait_for_moves=lambda: None)
+    win.camera = SimpleNamespace(snap=lambda: np.zeros((100, 200, 3), dtype=np.uint8))
+    win.capture_dir = str(tmp_path)
+    win.capture_name = "img"
+    win.auto_number = False
+    win.capture_format = "bmp"
+    win.chk_scale_bar.setChecked(True)
+    win.current_lens = Lens("test", 1.0)
+
+    saved = {}
+    win.image_writer = SimpleNamespace(save_single=lambda img, **kw: saved.setdefault("img", img))
+
+    def fake_run_async(fn, *args, **kwargs):
+        res = fn(*args, **kwargs)
+        class DummySignal:
+            def connect(self, cb):
+                cb(res, None)
+        return None, SimpleNamespace(finished=DummySignal())
+
+    monkeypatch.setattr(mw, "run_async", fake_run_async)
+
+    win._capture()
+    out = saved["img"]
+    assert np.all(out[80, 160:180] == 255)
+
+    win.preview_timer.stop()
+    win.fps_timer.stop()
+    win.close()

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -17,7 +17,7 @@ from ..control.focus_planes import (
     Area,
 )
 
-from ..utils.img import numpy_to_qimage
+from ..utils.img import numpy_to_qimage, draw_scale_bar
 from ..utils.log import LOG, log
 from ..utils.serial_worker import SerialWorker
 from ..utils.workers import run_async
@@ -1681,6 +1681,11 @@ class MainWindow(QtWidgets.QMainWindow):
             time.sleep(0.03)
             img = self.camera.snap()
             if img is not None:
+                if self.chk_scale_bar.isChecked():
+                    try:
+                        img = draw_scale_bar(img, self.current_lens.um_per_px)
+                    except Exception as e:
+                        log(f"Scale bar draw error: {e}")
                 self.image_writer.save_single(
                     img,
                     directory=directory,

--- a/microstage_app/utils/img.py
+++ b/microstage_app/utils/img.py
@@ -1,5 +1,8 @@
+import math
+
 import numpy as np
 from PySide6 import QtGui
+from PIL import Image, ImageDraw, ImageFont
 
 def numpy_to_qimage(img: np.ndarray) -> QtGui.QImage:
     if img.ndim == 2:
@@ -12,3 +15,61 @@ def numpy_to_qimage(img: np.ndarray) -> QtGui.QImage:
         return qimg.copy()
     else:
         raise ValueError(f"Unsupported image shape: {img.shape}")
+
+
+def draw_scale_bar(img: np.ndarray, um_per_px: float) -> np.ndarray:
+    """Draw a scale bar in-place on an RGB image array.
+
+    Parameters
+    ----------
+    img:
+        ``HxWx3`` RGB image data. Grayscale ``HxW`` arrays will be expanded to
+        RGB before drawing.
+    um_per_px:
+        Microns per pixel for the image. Must be positive.
+
+    Returns
+    -------
+    np.ndarray
+        The image with the scale bar overlay. A new array is returned as the
+        underlying conversion through :mod:`PIL` requires a copy.
+    """
+
+    if um_per_px <= 0:
+        return img
+
+    if img.ndim == 2:
+        img = np.repeat(img[:, :, None], 3, axis=2)
+    elif img.ndim != 3 or img.shape[2] != 3:
+        raise ValueError(f"Unsupported image shape: {img.shape}")
+
+    h, w, _ = img.shape
+
+    # Compute a "nice" length that fits within ~20% of the image width
+    max_um = 0.2 * w * um_per_px
+    exp = math.floor(math.log10(max_um)) if max_um > 0 else 0
+    nice_um = 10 ** exp
+    for m in (5, 2, 1):
+        candidate = m * (10 ** exp)
+        if candidate <= max_um:
+            nice_um = candidate
+            break
+
+    length_px = int(round(nice_um / um_per_px))
+    margin = 20
+    x0 = int(round(w - margin - length_px))
+    y0 = int(round(h - margin))
+
+    pil = Image.fromarray(img)
+    draw = ImageDraw.Draw(pil)
+    draw.line([(x0, y0), (x0 + length_px, y0)], fill=(255, 255, 255), width=2)
+
+    label = (
+        f"{nice_um/1000:.2f} mm" if nice_um >= 1000 else f"{nice_um:.0f} µm"
+    )
+    font = ImageFont.load_default()
+    bbox = draw.textbbox((0, 0), label, font=font)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    draw.text((x0, y0 - 7 - th), label, fill=(255, 255, 255), font=font)
+
+    return np.array(pil)


### PR DESCRIPTION
## Summary
- draw scale bar on numpy images using PIL so saved captures can include measurement
- invoke scale bar rendering during capture when the scale-bar option is enabled
- exercise new helper and capture path in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af890257808324817dff70704efa85