### PR TITLE
Reset ruler mode when line completed

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -332,6 +332,7 @@ class MeasureView(QtWidgets.QGraphicsView):
             self._live_line = None
             self._live_ticks = []
             self._live_text = None
+            self._mode = None
         super().mouseReleaseEvent(event)
 
     def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent) -> None:


### PR DESCRIPTION
## Summary
- reset measurement mode to None when releasing the mouse after drawing a ruler line

## Testing
- `python -m py_compile microstage_app/ui/main_window.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b035195ad883249997cfc065d1d7c8