### PR TITLE
Add camera color depth selection

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -14,6 +14,7 @@ DEFAULTS = {
         'hue': 0,
         'gamma': 100,
         'raw': False,
+        'color_depth': 8,
         'binning': 1,
         'resolution_index': 0,
         'display_decimation': 1,

--- a/microstage_app/devices/camera_mock.py
+++ b/microstage_app/devices/camera_mock.py
@@ -10,6 +10,8 @@ class MockCamera:
         self._exposure_ms = 10.0
         self._auto = False
         self._gain = 100
+        self._color_depths = [8, 16]
+        self._color_depth = 8
 
     def name(self): return "MockCamera"
     def start_stream(self): self._running = True
@@ -62,3 +64,15 @@ class MockCamera:
 
     def get_gain(self):
         return float(self._gain) / 100.0
+
+    # Color depth API ---------------------------------------------------------
+
+    def list_color_depths(self):
+        return list(self._color_depths)
+
+    def get_color_depth(self):
+        return int(self._color_depth)
+
+    def set_color_depth(self, depth: int):
+        if depth in self._color_depths:
+            self._color_depth = int(depth)

--- a/microstage_app/tests/test_camera_driver.py
+++ b/microstage_app/tests/test_camera_driver.py
@@ -19,3 +19,30 @@ def test_mock_camera_snap_shape():
     img = cam.snap()
     assert img.shape == (480, 640, 3)
     assert img.dtype.name == 'uint8'
+
+
+def test_list_color_depths_from_flags(monkeypatch):
+    tp = types.SimpleNamespace(
+        TOUPCAM_FLAG_RAW10=1 << 0,
+        TOUPCAM_FLAG_RAW12=1 << 1,
+        TOUPCAM_FLAG_RAW14=1 << 2,
+        TOUPCAM_FLAG_RAW16=1 << 3,
+    )
+
+    def fake_open(self):
+        self._color_depths = [8]
+        for depth, flag in [
+            (10, "TOUPCAM_FLAG_RAW10"),
+            (12, "TOUPCAM_FLAG_RAW12"),
+            (14, "TOUPCAM_FLAG_RAW14"),
+            (16, "TOUPCAM_FLAG_RAW16"),
+        ]:
+            if self._flags & getattr(self._tp, flag, 0):
+                self._color_depths.append(depth)
+        self._color_depth = self._color_depths[0]
+        self._cam = None
+
+    monkeypatch.setattr(camera_toupcam.ToupcamCamera, "_open", fake_open)
+    monkeypatch.setattr(camera_toupcam.ToupcamCamera, "_query_binning_options", lambda self: None)
+    cam = camera_toupcam.ToupcamCamera(tp, "id", "name", tp.TOUPCAM_FLAG_RAW10 | tp.TOUPCAM_FLAG_RAW14)
+    assert cam.list_color_depths() == [8, 10, 14]

--- a/microstage_app/tests/test_ui_mock_camera_connect.py
+++ b/microstage_app/tests/test_ui_mock_camera_connect.py
@@ -15,7 +15,10 @@ def qt_app():
 
 
 def test_ui_connects_with_mock_camera(monkeypatch, qt_app):
-    monkeypatch.setattr(mw, "create_camera", lambda: MockCamera())
+    cam = MockCamera()
+    called = []
+    cam.set_color_depth = lambda d: called.append(d)
+    monkeypatch.setattr(mw, "create_camera", lambda: cam)
     monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
 
     win = mw.MainWindow()
@@ -24,6 +27,10 @@ def test_ui_connects_with_mock_camera(monkeypatch, qt_app):
     assert win.camera is not None
     items = [win.res_combo.itemText(i) for i in range(win.res_combo.count())]
     assert items == ["640×480", "320×240"]
+    depth_items = [win.depth_combo.itemText(i) for i in range(win.depth_combo.count())]
+    assert depth_items == ["8-bit", "16-bit"]
+    win.depth_combo.setCurrentIndex(1)
+    assert called[-1] == 16
 
     win.preview_timer.stop()
     win.fps_timer.stop()


### PR DESCRIPTION
## Summary
- allow Toupcam cameras to report and change supported bit depths
- surface color depth selection in the UI and persist it in profiles
- add matching API to MockCamera with tests

## Testing
- `pytest microstage_app/tests/test_camera_driver.py microstage_app/tests/test_ui_mock_camera_connect.py tests/test_camera_settings_persist.py`

------
https://chatgpt.com/codex/tasks/task_e_68b036aaca4c8324a2f5155900691e41