### PR TITLE
Embed capture metadata in saved images

### DIFF
--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -101,6 +101,7 @@ class AutoFocus:
         metric: Optional[FocusMetric] = None,
         feed_mm_per_min: float = 240,
         fmt: str = "bmp",
+        lens_name: Optional[str] = None,
     ) -> Optional[int]:
         """Sweep Z over ``range_mm`` in ``step_mm`` increments and capture frames.
 
@@ -123,6 +124,8 @@ class AutoFocus:
             Feed rate for Z movement.
         fmt : str
             Image format passed to :meth:`ImageWriter.save_single`.
+        lens_name : str, optional
+            Name of the lens used for capture; included in image metadata.
 
         Returns
         -------
@@ -151,12 +154,19 @@ class AutoFocus:
                 if metric:
                     metrics.append(float("-inf"))
                 continue
+            pos = self.stage.get_position()
+            metadata = {
+                "Camera": self.camera.name(),
+                "Position": pos,
+                "Lens": lens_name,
+            }
             writer.save_single(
                 img,
                 directory=directory,
                 filename=f"{i:04d}",
                 auto_number=False,
                 fmt=fmt,
+                metadata=metadata,
             )
             if metric:
                 metrics.append(metric_value(img, metric))

--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -40,6 +40,7 @@ class RasterRunner:
         auto_number=False,
         fmt="tif",
         position_cb=None,
+        lens_name=None,
     ):
         self.stage = stage
         self.camera = camera
@@ -50,6 +51,7 @@ class RasterRunner:
         self.auto_number = auto_number
         self.fmt = fmt
         self.position_cb = position_cb
+        self.lens_name = lens_name
 
         self.coord_matrix = None
 
@@ -164,12 +166,19 @@ class RasterRunner:
                     if img is not None:
                         save_c = c
                         fname = f"{self.base_name}_r{r:04d}_c{save_c:04d}"
+                        pos = self.stage.get_position()
+                        metadata = {
+                            "Camera": self.camera.name(),
+                            "Position": pos,
+                            "Lens": self.lens_name,
+                        }
                         self.writer.save_single(
                             img,
                             directory=self.directory,
                             filename=fname,
                             auto_number=self.auto_number,
                             fmt=self.fmt,
+                            metadata=metadata,
                         )
                     time.sleep(1)
 

--- a/microstage_app/tests/test_autofocus.py
+++ b/microstage_app/tests/test_autofocus.py
@@ -15,6 +15,8 @@ class StageMock:
 class CameraMock:
     def snap(self):
         return object()
+    def name(self):
+        return "CameraMock"
 
 
 def test_autofocus_converges(monkeypatch):

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -31,12 +31,22 @@ class CameraMock:
     def snap(self):
         self.count += 1
         return self.count
+    def name(self):
+        return "CameraMock"
 
 class WriterMock:
     def __init__(self):
         self.saved = []
-    def save_single(self, img, directory=None, filename="capture", auto_number=False, fmt="bmp"):
-        self.saved.append((img, directory, filename, auto_number, fmt))
+    def save_single(
+        self,
+        img,
+        directory=None,
+        filename="capture",
+        auto_number=False,
+        fmt="bmp",
+        metadata=None,
+    ):
+        self.saved.append((img, directory, filename, auto_number, fmt, metadata))
 
 
 @pytest.mark.parametrize("mode", ["rectangle", "parallelogram", "trapezoid"])

--- a/microstage_app/tests/test_scale_bar.py
+++ b/microstage_app/tests/test_scale_bar.py
@@ -47,8 +47,11 @@ def test_draw_scale_bar_length_and_label(monkeypatch):
 
 def test_capture_contains_scale_bar(monkeypatch, tmp_path, qt_app):
     win = mw.MainWindow()
-    win.stage = SimpleNamespace(wait_for_moves=lambda: None)
-    win.camera = SimpleNamespace(snap=lambda: np.zeros((100, 200, 3), dtype=np.uint8))
+    win.stage = SimpleNamespace(wait_for_moves=lambda: None, get_position=lambda: (0, 0, 0))
+    win.camera = SimpleNamespace(
+        snap=lambda: np.zeros((100, 200, 3), dtype=np.uint8),
+        name=lambda: "CameraMock",
+    )
     win.capture_dir = str(tmp_path)
     win.capture_name = "img"
     win.auto_number = False

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1743,12 +1743,19 @@ class MainWindow(QtWidgets.QMainWindow):
                         img = draw_scale_bar(img, self.current_lens.um_per_px)
                     except Exception as e:
                         log(f"Scale bar draw error: {e}")
+                pos = self.stage.get_position()
+                meta = {
+                    "Camera": self.camera.name(),
+                    "Position": pos,
+                    "Lens": self.current_lens.name,
+                }
                 self.image_writer.save_single(
                     img,
                     directory=directory,
                     filename=name,
                     auto_number=auto_num,
                     fmt=self.capture_format,
+                    metadata=meta,
                 )
             return True
 
@@ -1978,6 +1985,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 metric=FocusMetric.LAPLACIAN,
                 feed_mm_per_min=feed,
                 fmt=self.capture_format,
+                lens_name=self.current_lens.name,
             )
 
         log(f"Focus stack: range={rng} step={step} dir={stack_dir}")
@@ -2071,6 +2079,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 position_cb=lambda pos: self.stage_worker.enqueue(
                     self.stage.get_position, callback=self._on_stage_position
                 ),
+                lens_name=self.current_lens.name,
             )
             runner.run()
             return True


### PR DESCRIPTION
## Summary
- Attach camera, stage position, and lens metadata when capturing a single image
- Propagate optional lens name and metadata through autofocus focus stacks
- Record metadata for each tile in raster scans

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b039324d408324895d01b0b0940354