### PR TITLE
Fix live measurement label update

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -220,7 +220,7 @@ class MeasureView(QtWidgets.QGraphicsView):
 
         pixels = length
         microns = pixels * self._um_per_px
-        self._live_text.setText(f"{pixels:.1f} px / {microns:.1f} µm")
+        self._live_text.setPlainText(f"{pixels:.1f} px / {microns:.1f} µm")
 
         if length > 0:
             unit_x = line.dx() / length


### PR DESCRIPTION
## Summary
- Fix distance label in MeasureView to use `setPlainText` and avoid AttributeError

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0403350888324ac3fd7a2fab64577