### PR TITLE
Add stop event pre-run check to RasterRunner

### DIFF
--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -138,6 +138,23 @@ def test_raster_initial_move():
     assert stage.moves_abs == [(0.0, 0.0, 0.0)]
 
 
+def test_raster_initial_move_cancelled():
+    stage = StageMock(x=1.0, y=1.0)
+    cam = CameraMock()
+    writer = WriterMock()
+    cfg = RasterConfig(rows=1, cols=1, x1_mm=0.0, y1_mm=0.0, capture=False)
+    runner = RasterRunner(stage, cam, writer, cfg)
+
+    stop_event = threading.Event()
+    stop_event.set()
+
+    runner.run(stop_event=stop_event)
+
+    assert stage.moves_abs == []
+    assert stage.moves == []
+    assert writer.saved == []
+
+
 @pytest.mark.parametrize(
     "autofocus,capture,expected",
     [


### PR DESCRIPTION
## Summary
- allow cancelling a raster scan via `stop_event` before the initial move
- add regression test to ensure no stage movement when stopped

## Testing
- `pytest microstage_app/tests/test_raster.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06320701083249fc921f15197972b