### PR TITLE
Use PNG as default capture format

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
 The capture panel lets you choose an output folder and base filename. The fields
 are validated: the directory must be writable (it will be created if missing) and
 the name cannot contain characters such as `\\ / : * ? \" < > |`. The directory,
-base name, and auto-number option are all remembered between runs.
+base name, and auto-number option are all remembered between runs. Captures
+default to PNG to retain embedded metadata, with BMP, TIFF and JPEG also
+available.
 
 Enabling **Auto-number (_n)** appends an incrementing suffix when a file with the
 same name already exists, preventing accidental overwrites.

--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -100,7 +100,7 @@ class AutoFocus:
         directory: Optional[str] = None,
         metric: Optional[FocusMetric] = None,
         feed_mm_per_min: float = 240,
-        fmt: str = "bmp",
+        fmt: str = "png",
         lens_name: Optional[str] = None,
     ) -> Optional[int]:
         """Sweep Z over ``range_mm`` in ``step_mm`` increments and capture frames.

--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -43,7 +43,7 @@ DEFAULTS = {
         }
     },
     # persistent capture settings
-    'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'bmp'},
+    'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'png'},
     # jog UI persistence
     'jog': {
         'step': {'x': 0.1, 'y': 0.1, 'z': 0.1},

--- a/microstage_app/tests/test_capture_metadata.py
+++ b/microstage_app/tests/test_capture_metadata.py
@@ -1,0 +1,60 @@
+import os
+import numpy as np
+from types import SimpleNamespace
+from PIL import Image
+import pytest
+from PySide6 import QtWidgets
+
+import microstage_app.ui.main_window as mw
+from microstage_app.control.profiles import Profiles
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_default_capture_preserves_metadata(monkeypatch, tmp_path, qt_app):
+    # use temp profiles file
+    monkeypatch.setattr(Profiles, "PATH", str(tmp_path / "profiles.yaml"))
+
+    # stub ImageWriter to write into tmp_path
+    def fake_init(self, base_dir='runs'):
+        self.base_dir = str(tmp_path)
+        self.run_dir = str(tmp_path)
+    monkeypatch.setattr(mw.ImageWriter, "__init__", fake_init)
+
+    # prevent auto-connect
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+
+    # run async immediately
+    def fake_run_async(fn, *args, **kwargs):
+        res = fn(*args, **kwargs)
+        class DummySignal:
+            def connect(self, cb):
+                cb(res, None)
+        return None, SimpleNamespace(finished=DummySignal())
+    monkeypatch.setattr(mw, "run_async", fake_run_async)
+
+    win = mw.MainWindow()
+    win.stage = SimpleNamespace(wait_for_moves=lambda: None, get_position=lambda: (1, 2, 3))
+    win.camera = SimpleNamespace(snap=lambda: np.zeros((5, 5, 3), dtype=np.uint8), name=lambda: "MockCam")
+    win.capture_dir = str(tmp_path)
+    win.capture_name = "meta_test"
+    win.auto_number = False
+    win.current_lens = SimpleNamespace(name="LensMock", um_per_px=1.0)
+
+    win._capture()
+
+    path = tmp_path / "meta_test.png"
+    assert path.exists()
+    img = Image.open(path)
+    assert img.info.get("Camera") == "MockCam"
+    assert img.info.get("Lens") == "LensMock"
+    assert img.info.get("Position") == "(1, 2, 3)"
+
+    win.preview_timer.stop(); win.fps_timer.stop(); win.close()

--- a/microstage_app/tests/test_capture_settings_persist.py
+++ b/microstage_app/tests/test_capture_settings_persist.py
@@ -34,9 +34,9 @@ def test_capture_settings_persist(monkeypatch, tmp_path, qt_app):
     win1.capture_dir_edit.setText(dir1)
     win1.capture_name_edit.setText("foo")
     win1.autonumber_chk.setChecked(True)
-    assert win1.capture_format == "bmp"
-    assert win1.format_combo.currentText() == "BMP"
-    win1.format_combo.setCurrentText("PNG")
+    assert win1.capture_format == "png"
+    assert win1.format_combo.currentText() == "PNG"
+    win1.format_combo.setCurrentText("BMP")
     qt_app.processEvents()
     win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
 
@@ -48,6 +48,6 @@ def test_capture_settings_persist(monkeypatch, tmp_path, qt_app):
     assert win2.capture_name_edit.text() == "foo"
     assert win2.auto_number is True
     assert win2.autonumber_chk.isChecked()
-    assert win2.capture_format == "png"
-    assert win2.format_combo.currentText() == "PNG"
+    assert win2.capture_format == "bmp"
+    assert win2.format_combo.currentText() == "BMP"
     win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()

--- a/microstage_app/tests/test_profile_validation.py
+++ b/microstage_app/tests/test_profile_validation.py
@@ -42,9 +42,9 @@ def test_invalid_profile_values(monkeypatch, tmp_path, qt_app):
     assert win.stepx_spin.value() == pytest.approx(0.100)
     # out-of-range value should fall back to default
     assert win.feedx_spin.value() == pytest.approx(50.0)
-    # invalid capture format should fall back to bmp
-    assert win.capture_format == "bmp"
-    assert win.format_combo.currentText() == "BMP"
+    # invalid capture format should fall back to png
+    assert win.capture_format == "png"
+    assert win.format_combo.currentText() == "PNG"
 
     win.preview_timer.stop(); win.fps_timer.stop(); win.close()
 

--- a/microstage_app/tests/test_scale_bar.py
+++ b/microstage_app/tests/test_scale_bar.py
@@ -55,7 +55,6 @@ def test_capture_contains_scale_bar(monkeypatch, tmp_path, qt_app):
     win.capture_dir = str(tmp_path)
     win.capture_name = "img"
     win.auto_number = False
-    win.capture_format = "bmp"
     win.chk_scale_bar.setChecked(True)
     win.current_lens = Lens("test", 1.0)
 

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -421,10 +421,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.capture_dir = dir_profile if dir_profile else self.image_writer.run_dir
         self.capture_name = self.profiles.get('capture.name', "capture", expected_type=str)
         self.auto_number = self.profiles.get('capture.auto_number', False, expected_type=bool)
-        fmt = self.profiles.get('capture.format', 'bmp', expected_type=str)
+        fmt = self.profiles.get('capture.format', 'png', expected_type=str)
         if fmt.lower() not in {"bmp", "tif", "png", "jpg"}:
-            log(f"WARNING: profile 'capture.format' has invalid value {fmt!r}; using default 'bmp'")
-            fmt = 'bmp'
+            log(f"WARNING: profile 'capture.format' has invalid value {fmt!r}; using default 'png'")
+            fmt = 'png'
         self.capture_format = fmt
 
         # timers


### PR DESCRIPTION
## Summary
- default capture format now PNG for metadata support
- fix profile fallback and focus stack defaults
- document PNG default and add metadata capture test

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b06643cabc8324b795acc5f65fee9b