### PR TITLE
Load TrueType font for scale bar with fallback

### DIFF
--- a/microstage_app/utils/img.py
+++ b/microstage_app/utils/img.py
@@ -81,8 +81,14 @@ def draw_scale_bar(img: np.ndarray, um_per_px: float) -> np.ndarray:
     label = (
         f"{nice_um/1000:.2f} mm" if nice_um >= 1000 else f"{nice_um:.0f} µm"
     )
-    font = ImageFont.load_default()
-    font = font.font_variant(size=font.size * TEXT_SCALE)
+
+    base_font = ImageFont.load_default()
+    font_size = base_font.size * TEXT_SCALE
+    try:
+        font = ImageFont.truetype("DejaVuSans.ttf", font_size)
+    except OSError:
+        font = base_font.font_variant(size=font_size)
+
     bbox = draw.textbbox((0, 0), label, font=font)
     th = bbox[3] - bbox[1]
     draw.text(


### PR DESCRIPTION
## Summary
- Use DejaVuSans TrueType font for scale bar labels and fall back to the default font when unavailable
- Mock ImageFont.truetype in scale bar tests for deterministic behavior

## Testing
- `pytest microstage_app/tests/test_scale_bar.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b06b0b12e883248ada7608914b3afa