### PR TITLE
Add optional scale bar overlay to raster captures

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -4,6 +4,8 @@ from math import isclose
 from threading import Event
 from typing import Optional
 
+from ..utils.img import draw_scale_bar
+
 try:
     from .autofocus import AutoFocus, FocusMetric
 except Exception:  # pragma: no cover - autofocus deps may be missing
@@ -43,6 +45,7 @@ class RasterRunner:
         fmt="tif",
         position_cb=None,
         lens_name=None,
+        scale_bar_um_per_px: Optional[float] = None,
     ):
         self.stage = stage
         self.camera = camera
@@ -54,6 +57,7 @@ class RasterRunner:
         self.fmt = fmt
         self.position_cb = position_cb
         self.lens_name = lens_name
+        self.scale_bar_um_per_px = scale_bar_um_per_px
 
         self.coord_matrix = None
         self._stop = False
@@ -180,6 +184,8 @@ class RasterRunner:
                 if do_capture:
                     img = self.camera.snap()
                     if img is not None:
+                        if self.scale_bar_um_per_px is not None:
+                            img = draw_scale_bar(img, self.scale_bar_um_per_px)
                         save_c = c
                         fname = f"{self.base_name}_r{r:04d}_c{save_c:04d}"
                         pos = self.stage.get_position()

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -285,3 +285,22 @@ def test_raster_trapezoid_matrix():
         [(0.5, 1.5), (2.0, 1.5), (3.5, 1.5)],
         [(1.0, 3.0), (2.0, 3.0), (3.0, 3.0)],
     ]
+
+
+def test_raster_scale_bar(monkeypatch):
+    stage = StageMock()
+    cam = CameraMock()
+    writer = WriterMock()
+    cfg = RasterConfig(rows=1, cols=1)
+    called = []
+
+    def fake_draw(img, um_per_px):
+        called.append(um_per_px)
+        return img
+
+    monkeypatch.setattr(raster, "draw_scale_bar", fake_draw)
+
+    runner = RasterRunner(stage, cam, writer, cfg, scale_bar_um_per_px=1.23)
+    runner.run()
+
+    assert called == [1.23]

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2191,6 +2191,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.stage.get_position, callback=self._on_stage_position
             ),
             lens_name=self.current_lens.name,
+            scale_bar_um_per_px=self.current_lens.um_per_px if self.chk_scale_bar.isChecked() else None,
         )
         self._raster_runner = runner
 


### PR DESCRIPTION
## Summary
- allow RasterRunner to overlay a scale bar during raster captures
- wire UI checkbox to pass lens scale to RasterRunner
- cover raster scale bar via unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0750f87e483249c2597f914bd9b1e