### PR TITLE
Ensure raster thread is properly stopped on exit

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2209,6 +2209,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if self._raster_runner:
             log("Raster: stop requested")
             self._raster_runner.stop()
+            if self._raster_thread:
+                self._raster_thread.quit()
+                self._raster_thread.wait()
         if self._level_thread:
             log("Leveling: stop requested")
             self._level_thread.requestInterruption()
@@ -2351,6 +2354,10 @@ class MainWindow(QtWidgets.QMainWindow):
             self.profiles.set(path, val)
         self.profiles.save()
         try:
+            self._stop_all()
+            if self._raster_thread:
+                self._raster_thread.quit()
+                self._raster_thread.wait()
             if self.stage_worker:
                 self.stage_worker.stop()
             if self.stage_thread:


### PR DESCRIPTION
## Summary
- Ensure `_stop_all` quits and waits for the raster thread before continuing
- Close event now stops raster operations and blocks until the raster thread terminates

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b076644e5c83249014a4369a1a87cf