### PR TITLE
Prevent concurrent raster runs

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2138,6 +2138,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if not (self.stage and self.camera):
             log("Raster ignored: stage or camera not connected")
             return
+        if self._raster_thread or self._raster_runner:
+            log("Raster ignored: raster already running")
+            QtWidgets.QMessageBox.warning(
+                self, "Raster", "A raster operation is already in progress."
+            )
+            return
         cfg = RasterConfig(
             rows=self.rows_spin.value(),
             cols=self.cols_spin.value(),


### PR DESCRIPTION
## Summary
- avoid starting a raster scan if one is already running

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0772782e88324af6c311906669714