### PR TITLE
Revise parallelogram raster coordinates

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -15,6 +15,14 @@ except Exception:  # pragma: no cover - autofocus deps may be missing
 
 @dataclass
 class RasterConfig:
+    """Configuration for raster scans.
+
+    For ``mode="parallelogram"`` the three defined points correspond to the
+    top-left (``x1_mm``, ``y1_mm``), top-right (``x2_mm``, ``y2_mm``), and
+    bottom-right (``x3_mm``, ``y3_mm``) corners of the area. The remaining
+    corner is inferred from these coordinates.
+    """
+
     rows: int = 5
     cols: int = 5
     x1_mm: float = 0.0
@@ -63,7 +71,11 @@ class RasterRunner:
         self._stop = False
 
     def _build_coord_matrix(self):
-        """Generate the coordinate matrix for the configured raster mode."""
+        """Generate the coordinate matrix for the configured raster mode.
+
+        For ``mode="parallelogram"`` the supplied points are interpreted as
+        top-left, top-right, and bottom-right corners respectively.
+        """
         if self.coord_matrix is not None:
             return self.coord_matrix
 
@@ -86,8 +98,8 @@ class RasterRunner:
         elif cfg.mode == "parallelogram":
             col_vec_x = (cfg.x2_mm - cfg.x1_mm) / (cfg.cols - 1) if cfg.cols > 1 else 0.0
             col_vec_y = (cfg.y2_mm - cfg.y1_mm) / (cfg.cols - 1) if cfg.cols > 1 else 0.0
-            row_vec_x = (cfg.x3_mm - cfg.x1_mm) / (cfg.rows - 1) if cfg.rows > 1 else 0.0
-            row_vec_y = (cfg.y3_mm - cfg.y1_mm) / (cfg.rows - 1) if cfg.rows > 1 else 0.0
+            row_vec_x = (cfg.x3_mm - cfg.x2_mm) / (cfg.rows - 1) if cfg.rows > 1 else 0.0
+            row_vec_y = (cfg.y3_mm - cfg.y2_mm) / (cfg.rows - 1) if cfg.rows > 1 else 0.0
             for r in range(cfg.rows):
                 row = []
                 for c in range(cfg.cols):

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -73,7 +73,7 @@ def test_raster_traversal_modes(mode, serpentine):
     if mode == "rectangle":
         cfg_kwargs.update(x2_mm=2.0, y2_mm=0.0, x3_mm=0.0, y3_mm=1.0, x4_mm=2.0, y4_mm=1.0)
     elif mode == "parallelogram":
-        cfg_kwargs.update(x2_mm=2.0, y2_mm=0.0, x3_mm=0.5, y3_mm=1.0)
+        cfg_kwargs.update(x2_mm=2.0, y2_mm=0.0, x3_mm=2.5, y3_mm=1.0)
     elif mode == "trapezoid":
         cfg_kwargs.update(x2_mm=4.0, y2_mm=0.0, x3_mm=1.0, y3_mm=2.0, x4_mm=3.0, y4_mm=2.0)
 
@@ -254,7 +254,7 @@ def test_raster_parallelogram_matrix():
         y1_mm=0.0,
         x2_mm=2.0,
         y2_mm=0.0,
-        x3_mm=0.5,
+        x3_mm=2.5,
         y3_mm=1.0,
         mode="parallelogram",
         capture=False,


### PR DESCRIPTION
## Summary
- fix parallelogram raster computation to use bottom-right point for row vector
- clarify parallelogram corner convention in `RasterConfig` and docs
- adjust tests for new point ordering

## Testing
- `QT_QPA_PLATFORM=offscreen pytest microstage_app/tests/test_raster.py::test_raster_parallelogram_matrix -q`
- `QT_QPA_PLATFORM=offscreen pytest microstage_app/tests/test_raster.py -k 'traversal_modes and parallelogram' -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b079bcc058832482a91b17b46b5991