### PR TITLE
Increase reticle pen thickness

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -112,7 +112,7 @@ class MeasureView(QtWidgets.QGraphicsView):
             cx = br.center().x()
             cy = br.center().y()
             painter.setCompositionMode(QtGui.QPainter.CompositionMode_Difference)
-            painter.setPen(QtGui.QPen(QtCore.Qt.white))
+            painter.setPen(QtGui.QPen(QtCore.Qt.white, 3 * VERT_SCALE))
             painter.drawLine(QtCore.QLineF(br.left(), cy, br.right(), cy))
             painter.drawLine(QtCore.QLineF(cx, br.top(), cx, br.bottom()))
             painter.restore()


### PR DESCRIPTION
## Summary
- Increase reticle line pen width in MeasureView by using `3 * VERT_SCALE`

## Testing
- `pytest` *(fails: Interrupted: 19 errors during collection)*
- `python -m microstage_app` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b07f972df08324878446ea995cc386