### PR TITLE
Replace display frame decimation with USB speed selector

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -91,7 +91,7 @@ Jog:
 
 Camera:
 - Exposure (ms) (Auto optional), Gain, RAW8 fast mono (8-bit; ~1/3 bandwidth vs RGB24), Resolution index,
-  ROI presets (Full, 2048^2, 1024^2, 512^2), and display decimation (show every Nth frame). USB bandwidth is fixed to level 5.
+  ROI presets (Full, 2048^2, 1024^2, 512^2), and selectable USB bandwidth level.
 - Smaller ROI / shorter exposure -> higher FPS.
 
 Capture:

--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -17,7 +17,7 @@ DEFAULTS = {
         'color_depth': 8,
         'binning': 1,
         'resolution_index': 0,
-        'display_decimation': 1,
+        'usb_speed': 5,
     },
     'scan_presets': {
         'raster': {

--- a/tests/test_camera_settings_persist.py
+++ b/tests/test_camera_settings_persist.py
@@ -33,7 +33,7 @@ def test_camera_settings_persist(tmp_path):
     w.hue_spin.setValue(5)
     w.gamma_spin.setValue(70)
     w.raw_chk.setChecked(True)
-    w.decim_spin.setValue(3)
+    w.speed_spin.setValue(3)
     w.close()
 
     w2 = MainWindow()
@@ -46,6 +46,6 @@ def test_camera_settings_persist(tmp_path):
     assert w2.hue_spin.value() == 5
     assert w2.gamma_spin.value() == 70
     assert w2.raw_chk.isChecked() is True
-    assert w2.decim_spin.value() == 3
+    assert w2.speed_spin.value() == 3
     w2.close()
     Profiles.PATH = orig_path


### PR DESCRIPTION
## Summary
- Allow selecting camera USB bandwidth level instead of dropping display frames
- Remove frame-decimation UI and persistence
- Add USB speed level persistence and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0981c76c08324bf28b32569aa8a23