### PR TITLE
Handle lowercase axis labels in Marlin position parsing

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -214,19 +214,19 @@ class StageMarlin:
         # machine coordinates remain.
         before_count = re.split(r"count", resp, flags=re.IGNORECASE)[0]
         x = y = z = None
-        m = re.search(r"X:\s*([-+]?\d*\.?\d+)", before_count)
+        m = re.search(r"X:\s*([-+]?\d*\.?\d+)", before_count, flags=re.IGNORECASE)
         if m:
             try:
                 x = float(m.group(1))
             except ValueError:
                 pass
-        m = re.search(r"Y:\s*([-+]?\d*\.?\d+)", before_count)
+        m = re.search(r"Y:\s*([-+]?\d*\.?\d+)", before_count, flags=re.IGNORECASE)
         if m:
             try:
                 y = float(m.group(1))
             except ValueError:
                 pass
-        m = re.search(r"Z:\s*([-+]?\d*\.?\d+)", before_count)
+        m = re.search(r"Z:\s*([-+]?\d*\.?\d+)", before_count, flags=re.IGNORECASE)
         if m:
             try:
                 z = float(m.group(1))

--- a/microstage_app/tests/test_stage_marlin_get_position.py
+++ b/microstage_app/tests/test_stage_marlin_get_position.py
@@ -24,9 +24,10 @@ def qt_app():
 
 
 def test_get_position_and_label(monkeypatch, qt_app):
+    # Use lowercase axis labels to ensure parsing is case-insensitive
     responses = [
-        "X:1.00 Y:0.00 Z:1.00 E:0.00 count X:0 Y:0 Z:0",
-        "X:1.00 Y:0.00 Z:2.00 E:0.00 count X:0 Y:0 Z:0",
+        "x:1.00 y:0.00 z:1.00 e:0.00 count x:0 y:0 z:0",
+        "x:1.00 y:0.00 z:2.00 e:0.00 count x:0 y:0 z:0",
     ]
     stage = FakeStage(responses)
     x1, _, z1 = stage.get_position()


### PR DESCRIPTION
## Summary
- Make StageMarlin `get_position` regex searches case-insensitive
- Test that lowercase axis labels still update Z in the UI

## Testing
- `pytest microstage_app/tests/test_stage_marlin_get_position.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0afd637b483248c4c5770d85d2894