### PR TITLE
Ensure raster thread is fully terminated before clearing

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2340,6 +2340,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @QtCore.Slot(object, object)
     def _on_raster_finished(self, res, err):
+        thread = self._raster_thread
+        if thread and thread.isRunning():
+            thread.wait()
         self._raster_runner = None
         self._raster_thread = None
         self._raster_worker = None


### PR DESCRIPTION
## Summary
- Prevent QThread destruction warnings by waiting for the raster thread to finish before resetting thread-related attributes

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_raster.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0b0f49e108324bd12f668d1b6ad54