### PR TITLE
Permit manual movement while leveling

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2077,8 +2077,10 @@ class MainWindow(QtWidgets.QMainWindow):
             self.focus_mgr.areas.clear()
             self.focus_mgr.add_area(area)
             return model
-
-        self._set_movement_controls_enabled(False)
+        # Allow manual stage movement while leveling so users can position
+        # the stage if needed. Previously movement controls were disabled
+        # here which prevented manual adjustments during the leveling
+        # process.
         t, w = run_async(do_level)
         self._level_thread, self._level_worker = t, w
         self._level_thread.finished.connect(self._cleanup_leveling_thread)

--- a/tests/test_leveling_manual_controls.py
+++ b/tests/test_leveling_manual_controls.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from PySide6 import QtWidgets
+from microstage_app.ui import main_window
+
+
+class DummySignal:
+    def connect(self, *args, **kwargs):
+        pass
+
+
+class DummyThread:
+    finished = DummySignal()
+
+
+class DummyWorker:
+    finished = DummySignal()
+
+
+def dummy_run_async(fn, *args, **kwargs):
+    # Return dummy thread/worker without executing fn to keep test fast and
+    # avoid modal dialogs.
+    return DummyThread(), DummyWorker()
+
+
+def test_manual_controls_remain_enabled_during_leveling(monkeypatch):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    win = main_window.MainWindow()
+    win.stage = object()
+    win.level_mode.setCurrentText("Manual")
+    win.level_method.setCurrentText("Three-point")
+
+    monkeypatch.setattr(main_window, "run_async", dummy_run_async)
+
+    # Movement controls should be enabled before and after starting leveling.
+    assert win.btn_xp.isEnabled()
+    assert win.btn_xm.isEnabled()
+    assert win.btn_home_x.isEnabled()
+
+    win._run_leveling()
+
+    assert win.btn_xp.isEnabled()
+    assert win.btn_xm.isEnabled()
+    assert win.btn_home_x.isEnabled()
+
+    # Cleanup should still leave movement controls enabled.
+    win._cleanup_leveling_thread()
+    assert win.btn_xp.isEnabled()


### PR DESCRIPTION
## Summary
- Keep movement controls active during bed leveling so users can reposition the stage manually
- Ensure leveling cleanup still re-enables movement controls
- Add regression test verifying movement buttons remain enabled during leveling

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0ba4032e88324bb46f6ac6c208ccc