### PR TITLE
Add raster mode control enablement test

### DIFF
--- a/microstage_app/tests/test_ui_raster_modes.py
+++ b/microstage_app/tests/test_ui_raster_modes.py
@@ -64,6 +64,37 @@ def make_window(monkeypatch, tmp_path, qt_app):
     yield win, captured
     win.preview_timer.stop(); win.fps_timer.stop(); win.close()
 
+
+def test_raster_mode_control_enablement(make_window, qt_app):
+    win, _ = make_window
+
+    win.raster_mode_combo.setCurrentText("2-point")
+    qt_app.processEvents()
+    assert not win.rast_x3_spin.isEnabled()
+    assert not win.rast_y3_spin.isEnabled()
+    assert not win.btn_raster_p3.isEnabled()
+    assert not win.rast_x4_spin.isEnabled()
+    assert not win.rast_y4_spin.isEnabled()
+    assert not win.btn_raster_p4.isEnabled()
+
+    win.raster_mode_combo.setCurrentText("3-point")
+    qt_app.processEvents()
+    assert win.rast_x3_spin.isEnabled()
+    assert win.rast_y3_spin.isEnabled()
+    assert win.btn_raster_p3.isEnabled()
+    assert not win.rast_x4_spin.isEnabled()
+    assert not win.rast_y4_spin.isEnabled()
+    assert not win.btn_raster_p4.isEnabled()
+
+    win.raster_mode_combo.setCurrentText("4-point")
+    qt_app.processEvents()
+    assert win.rast_x3_spin.isEnabled()
+    assert win.rast_y3_spin.isEnabled()
+    assert win.btn_raster_p3.isEnabled()
+    assert win.rast_x4_spin.isEnabled()
+    assert win.rast_y4_spin.isEnabled()
+    assert win.btn_raster_p4.isEnabled()
+
 def test_raster_mode_two_point(make_window):
     win, captured = make_window
     win.raster_mode_combo.setCurrentText("2-point")

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -911,6 +911,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._reload_profiles()
         self._update_stage_buttons()
         self._update_cam_buttons()
+        self._update_raster_mode()
 
     def _refresh_lens_combo(self):
         self.lens_combo.blockSignals(True)
@@ -928,6 +929,15 @@ class MainWindow(QtWidgets.QMainWindow):
         grid = self.level_method.currentText() == "Grid"
         self.level_rows.setEnabled(grid)
         self.level_cols.setEnabled(grid)
+
+    def _update_raster_mode(self):
+        mode = self.raster_mode_combo.currentText()
+        p3 = mode in ("3-point", "4-point")
+        p4 = mode == "4-point"
+        for w in (self.rast_x3_spin, self.rast_y3_spin, self.btn_raster_p3):
+            w.setEnabled(p3)
+        for w in (self.rast_x4_spin, self.rast_y4_spin, self.btn_raster_p4):
+            w.setEnabled(p4)
 
     def _connect_signals(self):
         self.btn_stage_connect.clicked.connect(self._connect_stage_async)
@@ -955,6 +965,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_apply_level.clicked.connect(self._apply_leveling)
         self.btn_disable_level.clicked.connect(self._disable_leveling)
         self.level_method.currentTextChanged.connect(self._update_leveling_method)
+        self.raster_mode_combo.currentTextChanged.connect(self._update_raster_mode)
         self.btn_focus_stack.clicked.connect(self._run_focus_stack)
         self.btn_raster_p1.clicked.connect(lambda: self._set_raster_point(1))
         self.btn_raster_p2.clicked.connect(lambda: self._set_raster_point(2))


### PR DESCRIPTION
## Summary
- ensure P3/P4 UI controls enable correctly when switching raster modes
- update MainWindow to toggle controls based on selected raster mode

## Testing
- `pytest microstage_app/tests/test_ui_raster_modes.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c207a61083249ac14b5b877362a9