### PR TITLE
Use system font for scale bar micro symbol

### DIFF
--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -1,4 +1,3 @@
-import os
 import threading
 from types import SimpleNamespace
 
@@ -328,7 +327,7 @@ def test_raster_capture_contains_scale_bar(monkeypatch):
     orig_truetype = ImageFont.truetype
 
     def fake_truetype(font, size=10, *args, **kwargs):
-        if isinstance(font, (str, bytes)) and os.path.basename(font) == "DejaVuSans.ttf":
+        if isinstance(font, (str, bytes)):
             raise OSError("missing font")
         return orig_truetype(font, size, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- resolve current Qt font via `fc-match` for scale bar rendering
- warn and fall back to default font if system font lookup fails
- adjust regression tests to simulate missing fonts and verify µ glyph rendering

## Testing
- `pytest microstage_app/tests/test_scale_bar.py microstage_app/tests/test_raster.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0cbc577748324bc430ee0aea91aec