### PR TITLE
Fix missing raster control method

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -492,7 +492,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._connect_signals()
         self._init_persistent_fields()
         self._update_leveling_method()
-        self._update_raster_controls()
+        # ensure raster UI reflects current mode after loading profiles
+        self._update_raster_mode()
 
         # mirror logs to the in-app log pane
         LOG.message.connect(self._append_log)


### PR DESCRIPTION
## Summary
- Fix startup error by calling `_update_raster_mode` after loading profiles

## Testing
- `pytest microstage_app/tests/test_ui_raster_modes.py::test_raster_mode_control_enablement -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b170e62770832481c2ecafbf7f0765