### PR TITLE
Add rich metadata to captured images

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import time
+import datetime
 from math import isclose
 from threading import Event
 from typing import Optional
@@ -53,6 +54,7 @@ class RasterRunner:
         fmt="tif",
         position_cb=None,
         lens_name=None,
+        lens_um_per_px: Optional[float] = None,
         scale_bar_um_per_px: Optional[float] = None,
     ):
         self.stage = stage
@@ -65,6 +67,7 @@ class RasterRunner:
         self.fmt = fmt
         self.position_cb = position_cb
         self.lens_name = lens_name
+        self.lens_um_per_px = lens_um_per_px
         self.scale_bar_um_per_px = scale_bar_um_per_px
 
         self.coord_matrix = None
@@ -205,6 +208,12 @@ class RasterRunner:
                             "Camera": self.camera.name(),
                             "Position": pos,
                             "Lens": self.lens_name,
+                            "LensUmPerPx": self.lens_um_per_px,
+                            "Exposure_ms": getattr(self.camera, "get_exposure_ms", lambda: None)(),
+                            "Gain": getattr(self.camera, "get_gain", lambda: None)(),
+                            "Time": datetime.datetime.now().isoformat(),
+                            "Row": r,
+                            "Column": save_c,
                         }
                         self.writer.save_single(
                             img,

--- a/microstage_app/tests/test_capture_metadata.py
+++ b/microstage_app/tests/test_capture_metadata.py
@@ -42,7 +42,12 @@ def test_default_capture_preserves_metadata(monkeypatch, tmp_path, qt_app):
 
     win = mw.MainWindow()
     win.stage = SimpleNamespace(wait_for_moves=lambda: None, get_position=lambda: (1, 2, 3))
-    win.camera = SimpleNamespace(snap=lambda: np.zeros((5, 5, 3), dtype=np.uint8), name=lambda: "MockCam")
+    win.camera = SimpleNamespace(
+        snap=lambda: np.zeros((5, 5, 3), dtype=np.uint8),
+        name=lambda: "MockCam",
+        get_exposure_ms=lambda: 12.3,
+        get_gain=lambda: 1.5,
+    )
     win.capture_dir = str(tmp_path)
     win.capture_name = "meta_test"
     win.auto_number = False
@@ -56,5 +61,9 @@ def test_default_capture_preserves_metadata(monkeypatch, tmp_path, qt_app):
     assert img.info.get("Camera") == "MockCam"
     assert img.info.get("Lens") == "LensMock"
     assert img.info.get("Position") == "(1, 2, 3)"
+    assert img.info.get("Exposure_ms") == "12.3"
+    assert img.info.get("Gain") == "1.5"
+    assert img.info.get("LensUmPerPx") == "1.0"
+    assert "Time" in img.info
 
     win.preview_timer.stop(); win.fps_timer.stop(); win.close()

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -85,6 +85,7 @@ def test_raster_traversal_modes(mode, serpentine):
     # expected moves and filenames
     expected_moves = []
     expected_files = []
+    expected_meta = []
     current_x, current_y = coord_matrix[0][0]
     for r in range(cfg.rows):
         forward = (r % 2 == 0) or (not serpentine)
@@ -97,9 +98,12 @@ def test_raster_traversal_modes(mode, serpentine):
                 expected_moves.append((dx, dy, 0.0))
             current_x, current_y = target_x, target_y
             expected_files.append(f"foo_r{r:04d}_c{c:04d}")
+            expected_meta.append((r, c))
 
     assert stage.moves == expected_moves
     assert [f[2] for f in writer.saved] == expected_files
+    assert [m[5]["Row"] for m in writer.saved] == [r for r, _ in expected_meta]
+    assert [m[5]["Column"] for m in writer.saved] == [c for _, c in expected_meta]
 
 
 def test_raster_capture_disabled():

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -27,6 +27,7 @@ import os
 import re
 import time
 import math
+import datetime
 
 
 def _load_stage_bounds():
@@ -1845,6 +1846,10 @@ class MainWindow(QtWidgets.QMainWindow):
                     "Camera": self.camera.name(),
                     "Position": pos,
                     "Lens": self.current_lens.name,
+                    "LensUmPerPx": self.current_lens.um_per_px,
+                    "Exposure_ms": getattr(self.camera, "get_exposure_ms", lambda: None)(),
+                    "Gain": getattr(self.camera, "get_gain", lambda: None)(),
+                    "Time": datetime.datetime.now().isoformat(),
                 }
                 self.image_writer.save_single(
                     img,
@@ -2324,6 +2329,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.stage.get_position, callback=self._on_stage_position
             ),
             lens_name=self.current_lens.name,
+            lens_um_per_px=self.current_lens.um_per_px,
             scale_bar_um_per_px=self.current_lens.um_per_px if self.chk_scale_bar.isChecked() else None,
         )
         self._raster_runner = runner


### PR DESCRIPTION
## Summary
- include camera settings, lens calibration, acquisition time and stage position when capturing images
- track raster row/column and lens calibration for each tile
- extend tests for capture and raster metadata

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b174bd1c4483249b82939b58aedd72