### PR TITLE
Persist leveling equation in UI

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -803,6 +803,8 @@ class MainWindow(QtWidgets.QMainWindow):
         l.addWidget(self.btn_apply_level, row, 0, 1, 2); row += 1
         l.addWidget(self.btn_disable_level, row, 0, 1, 2); row += 1
         l.addWidget(self.level_status, row, 0, 1, 2); row += 1
+        self.level_equation = QtWidgets.QLabel("")
+        l.addWidget(self.level_equation, row, 0, 1, 2); row += 1
         self.level_prompt = QtWidgets.QLabel("")
         self.level_prompt.setVisible(False)
         self.btn_level_continue = QtWidgets.QPushButton("Next")
@@ -1946,16 +1948,13 @@ class MainWindow(QtWidgets.QMainWindow):
         if err:
             log(f"Leveling error: {err}")
             self._set_leveling_status("Error")
+            self.level_equation.setText("")
             QtWidgets.QMessageBox.critical(self, "Leveling", str(err))
         else:
             self._set_leveling_status("Complete")
             eq = model.equation() if model else ""
             log(f"Leveling model ({model.kind.value}): {eq}")
-            QtWidgets.QMessageBox.information(
-                self,
-                "Leveling",
-                f"Leveling complete.\n{model.kind.value} model: {eq}",
-            )
+            self.level_equation.setText(eq)
 
     @QtCore.Slot(str)
     def _set_leveling_status(self, text: str):
@@ -1975,6 +1974,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.focus_mgr.areas.clear()
         self.leveling_enabled = False
         self._set_leveling_status("Disabled")
+        self.level_equation.setText("")
 
     @QtCore.Slot(str)
     def _set_level_prompt(self, text: str):


### PR DESCRIPTION
## Summary
- Display fitted leveling equation in a new label within the Leveling group
- Show equation in the label when leveling finishes and clear it when disabling leveling

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b18945314c83249ba10e7e7c02d6b8