### PR TITLE
Add basic USB webcam support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
    ```
    On Linux, OpenCV (`opencv-python`) requires the system library `libGL.so.1`.
    Install it via your package manager, e.g. `sudo apt-get install -y libgl1`,
-   or run the helper script `scripts/install_libgl1.sh`. For headless setups,
-   you may instead install `opencv-python-headless` to avoid the `libGL`
-   dependency.
+ or run the helper script `scripts/install_libgl1.sh`. For headless setups,
+  you may instead install `opencv-python-headless` to avoid the `libGL`
+  dependency.
 3. Install the **ToupTek / Toupcam SDK for Windows**. Copy the `toupcam.dll` (x64) next to `main.py` (or put it in your PATH).
    The SDK usually ships `toupcam.py` and examples; this app will auto-import if present.
+   Basic USB webcams are also supported via OpenCV's ``VideoCapture`` and do not
+   require this SDK, though only simple streaming and resolution selection are
+   available.
 4. Connect your **Marlin** stage (Mega2560+RAMPS), power it on.
 5. Run the app:
    ```bash
@@ -27,7 +30,7 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
 > No camera? The app falls back to a software **MockCamera** so you can test UI and scans.
 
 ## Features
-- Device discovery: auto-detects Marlin via `M115` (verifying custom machine name and optional UUID) and ToupCam via SDK enumerate.
+- Device discovery: auto-detects Marlin via `M115` (verifying custom machine name and optional UUID), ToupCam via SDK enumeration, and probes a couple of OpenCV webcam indices.
 - Live preview + jog controls (XY/Z), home, go-to.
 - Capture primitives: move → settle → snap.
 - Modes: Area (serpentine), Timelapse, Combined.

--- a/microstage_app/devices/camera_webcam.py
+++ b/microstage_app/devices/camera_webcam.py
@@ -1,0 +1,85 @@
+try:
+    import cv2
+except Exception:  # pragma: no cover - handled gracefully when OpenCV missing
+    cv2 = None
+
+
+class WebcamCamera:
+    """Minimal USB webcam wrapper using OpenCV's :class:`VideoCapture`.
+
+    This class mirrors the subset of :class:`MockCamera`'s API that the
+    application relies on. It supports starting/stopping a video stream,
+    grabbing the latest frame, taking a snapshot, and choosing between a couple
+    of common resolutions.
+    """
+
+    def __init__(self, index: int = 0):
+        if cv2 is None:
+            raise RuntimeError("OpenCV is required for WebcamCamera")
+        self._index = int(index)
+        self._cap = None
+        self._running = False
+        self._latest = None
+        self._resolution_idx = 0
+        # A small set of typical webcam resolutions
+        self._resolutions = [
+            (0, 640, 480),
+            (1, 320, 240),
+        ]
+
+    # ------------------------------------------------------------------
+    # Basic stream control
+    def name(self):
+        return f"Webcam {self._index}"
+
+    def start_stream(self):
+        if self._running:
+            return
+        self._cap = cv2.VideoCapture(self._index)
+        self._apply_resolution()
+        self._running = True
+
+    def stop_stream(self):
+        if self._cap is not None:
+            try:
+                self._cap.release()
+            except Exception:
+                pass
+            self._cap = None
+        self._running = False
+
+    # ------------------------------------------------------------------
+    def _apply_resolution(self):
+        try:
+            _, w, h = self.list_resolutions()[self._resolution_idx]
+        except Exception:
+            _, w, h = self.list_resolutions()[0]
+        if self._cap is not None:
+            self._cap.set(cv2.CAP_PROP_FRAME_WIDTH, int(w))
+            self._cap.set(cv2.CAP_PROP_FRAME_HEIGHT, int(h))
+
+    def get_latest_frame(self):
+        if not self._running:
+            self.start_stream()
+        ret, frame = self._cap.read()
+        if not ret:
+            raise RuntimeError("Failed to read frame from webcam")
+        # Convert BGR -> RGB for consistency with other drivers
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        self._latest = frame
+        return frame
+
+    def snap(self):
+        return self.get_latest_frame()
+
+    # ------------------------------------------------------------------
+    # Resolution handling
+    def list_resolutions(self):
+        return list(self._resolutions)
+
+    def set_resolution_index(self, idx):
+        self._resolution_idx = int(idx)
+        self._apply_resolution()
+
+    def get_resolution_index(self):
+        return int(self._resolution_idx)

--- a/microstage_app/tests/test_webcam_driver.py
+++ b/microstage_app/tests/test_webcam_driver.py
@@ -1,0 +1,49 @@
+import sys
+import types
+import numpy as np
+import pytest
+
+import microstage_app.devices.camera_toupcam as camera_toupcam
+
+
+def test_webcam_list_and_create(monkeypatch):
+    # Simulate absence of toupcam SDK
+    def raise_import():
+        raise ImportError
+    monkeypatch.setattr(camera_toupcam, '_import_toupcam', raise_import)
+
+    # Dummy cv2 with a single working webcam at index 0
+    class DummyCap:
+        def __init__(self, idx):
+            self.idx = idx
+            self._open = idx == 0
+        def isOpened(self):
+            return self._open
+        def release(self):
+            pass
+        def read(self):
+            return True, np.zeros((480, 640, 3), dtype=np.uint8)
+        def set(self, prop, value):
+            pass
+
+    dummy_cv2 = types.SimpleNamespace(
+        VideoCapture=lambda idx: DummyCap(idx),
+        CAP_PROP_FRAME_WIDTH=3,
+        CAP_PROP_FRAME_HEIGHT=4,
+        COLOR_BGR2RGB=None,
+        cvtColor=lambda frame, code: frame,
+    )
+
+    monkeypatch.setitem(sys.modules, 'cv2', dummy_cv2)
+    monkeypatch.setattr(camera_toupcam, 'cv2', dummy_cv2)
+
+    import microstage_app.devices.camera_webcam as camera_webcam
+    monkeypatch.setattr(camera_webcam, 'cv2', dummy_cv2)
+
+    cams = camera_toupcam.list_cameras()
+    assert ("webcam:0", "Webcam 0") in cams
+
+    cam = camera_toupcam.create_camera('webcam:0')
+    assert isinstance(cam, camera_webcam.WebcamCamera)
+    img = cam.snap()
+    assert img.shape == (480, 640, 3)


### PR DESCRIPTION
## Summary
- add WebcamCamera wrapping OpenCV VideoCapture
- probe for webcams in list_cameras and dispatch via create_camera
- document USB webcam support in README
- test webcam driver detection and creation

## Testing
- `pytest microstage_app/tests/test_webcam_driver.py microstage_app/tests/test_camera_driver.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b18dcb96c88324b3da2a19b49c5949