### PR TITLE
Enable camera control availability checks

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1240,6 +1240,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._sync_cam_controls()
             self.preview_timer.start()
             self.fps_timer.start()
+            self._update_camera_control_availability()
             log("UI: camera connected")
         except Exception as e:
             log(f"UI: camera connect failed: {e}")
@@ -1259,6 +1260,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.res_combo.clear()
         self.bin_combo.clear()
         self.depth_combo.clear()
+        self._update_camera_control_availability(None)
 
     def _connect_stage_async(self, port=None):
         if self.stage is not None:
@@ -1582,6 +1584,29 @@ class MainWindow(QtWidgets.QMainWindow):
         self.speed_spin.setValue(val)
         self.speed_spin.blockSignals(False)
         self._apply_speed()
+    def _update_camera_control_availability(self, cam=None):
+        cam = cam if cam is not None else self.camera
+        has = lambda attr: cam is not None and hasattr(cam, attr)
+        auto = self.autoexp_chk.isChecked()
+        self.autoexp_chk.setEnabled(has("set_exposure_ms"))
+        self.exp_spin.setEnabled(has("set_exposure_ms") and not auto)
+        self.gain_spin.setEnabled(has("set_gain") and not auto)
+        self.brightness_spin.setEnabled(has("set_brightness"))
+        self.brightness_slider.setEnabled(has("set_brightness"))
+        self.contrast_spin.setEnabled(has("set_contrast"))
+        self.contrast_slider.setEnabled(has("set_contrast"))
+        self.saturation_spin.setEnabled(has("set_saturation"))
+        self.saturation_slider.setEnabled(has("set_saturation"))
+        self.hue_spin.setEnabled(has("set_hue"))
+        self.hue_slider.setEnabled(has("set_hue"))
+        self.gamma_spin.setEnabled(has("set_gamma"))
+        self.gamma_slider.setEnabled(has("set_gamma"))
+        self.raw_chk.setEnabled(has("set_raw_fast_mono"))
+        roi = has("set_center_roi")
+        self.btn_roi_full.setEnabled(roi)
+        self.btn_roi_2048.setEnabled(roi)
+        self.btn_roi_1024.setEnabled(roi)
+        self.btn_roi_512.setEnabled(roi)
 
     def _sync_cam_controls(self):
         if not self.camera:
@@ -1642,6 +1667,7 @@ class MainWindow(QtWidgets.QMainWindow):
             finally:
                 self.exp_spin.blockSignals(False)
                 self.gain_spin.blockSignals(False)
+        self._update_camera_control_availability()
 
     def _apply_gain(self, again=None):
         if not self.camera:

--- a/tests/test_ui_control_availability.py
+++ b/tests/test_ui_control_availability.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from PySide6 import QtWidgets, QtCore
+from microstage_app.ui import main_window
+
+
+class FakeCam:
+    def name(self):
+        return "FakeCam"
+
+    def start_stream(self):
+        pass
+
+    def stop_stream(self):
+        pass
+
+    def set_exposure_ms(self, ms, auto):
+        pass
+
+    def set_gain(self, gain):
+        pass
+
+
+def test_widgets_disabled_when_capability_missing(monkeypatch):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    win = main_window.MainWindow()
+
+    monkeypatch.setattr(main_window, "create_camera", lambda dev_id=None: FakeCam())
+    monkeypatch.setattr(main_window.MainWindow, "_populate_speed_levels", lambda self: None)
+    monkeypatch.setattr(main_window.MainWindow, "_apply_speed", lambda self: None)
+    monkeypatch.setattr(main_window.MainWindow, "_populate_color_depths", lambda self: None)
+    monkeypatch.setattr(main_window.MainWindow, "_populate_binning", lambda self: None)
+    monkeypatch.setattr(main_window.MainWindow, "_populate_resolutions", lambda self: None)
+    monkeypatch.setattr(main_window.MainWindow, "_apply_camera_profile", lambda self: None)
+    monkeypatch.setattr(main_window.MainWindow, "_sync_cam_controls", lambda self: None)
+    monkeypatch.setattr(QtCore.QTimer, "singleShot", lambda ms, func: func())
+
+    win.preview_timer.start = lambda *a, **k: None
+    win.fps_timer.start = lambda *a, **k: None
+
+    win._connect_camera()
+
+    assert win.exp_spin.isEnabled()
+    assert not win.brightness_spin.isEnabled()
+    assert not win.brightness_slider.isEnabled()


### PR DESCRIPTION
## Summary
- Add helper to toggle camera UI controls based on capability setters
- Re-evaluate controls when connecting/disconnecting cameras and after auto-exposure changes
- Cover availability logic with a Qt-based FakeCam test

## Testing
- `pytest tests/test_ui_control_availability.py -q` *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b18fac90cc8324af3ed8630884b6d4