### PR TITLE
Document USB webcam detection and unsupported controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
    The SDK usually ships `toupcam.py` and examples; this app will auto-import if present.
    Basic USB webcams are also supported via OpenCV's ``VideoCapture`` and do not
    require this SDK, though only simple streaming and resolution selection are
-   available.
+   available. The app probes a handful of ``VideoCapture`` indices (0–3) to
+   discover attached USB cameras. Generic webcam support depends on the
+   ``opencv-python`` package, and any camera controls not exposed by a webcam
+   (e.g. brightness or gain) will appear greyed out in the UI.
 4. Connect your **Marlin** stage (Mega2560+RAMPS), power it on.
 5. Run the app:
    ```bash
@@ -28,6 +31,12 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
    ```
 
 > No camera? The app falls back to a software **MockCamera** so you can test UI and scans.
+
+### Troubleshooting
+
+Certain sliders or checkboxes may be disabled if the connected webcam does not
+advertise those capabilities. Only controls for features reported by the camera
+will be enabled.
 
 ## Features
 - Device discovery: auto-detects Marlin via `M115` (verifying custom machine name and optional UUID), ToupCam via SDK enumeration, and probes a couple of OpenCV webcam indices.


### PR DESCRIPTION
## Summary
- clarify how the app detects generic USB webcams and requires OpenCV
- note that unsupported camera controls are greyed out
- add troubleshooting note about disabled sliders or checkboxes

## Testing
- `pytest` *(fails: AttributeError in `test_dispatch_stage_result.py`, AssertionError in `test_resolution_combo.py`, `test_stage_marlin_get_position.py`, `test_ui_mock_camera_connect.py`, and `test_ui_stage_status_uuid.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68b190b3f79c832489f0bb0725694a38