### PR TITLE
Add raster focus stack tests

### DIFF
--- a/microstage_app/tests/test_ui_raster_modes.py
+++ b/microstage_app/tests/test_ui_raster_modes.py
@@ -150,3 +150,20 @@ def test_raster_mode_four_point(make_window):
     assert cfg.y3_mm == pytest.approx(3.0)
     assert cfg.x4_mm == pytest.approx(5.0)
     assert cfg.y4_mm == pytest.approx(3.0)
+
+
+def test_raster_stack_config(make_window):
+    win, captured = make_window
+    win.raster_mode_combo.setCurrentText("2-point")
+    win.rast_x1_spin.setValue(0.0)
+    win.rast_y1_spin.setValue(0.0)
+    win.rast_x2_spin.setValue(1.0)
+    win.rast_y2_spin.setValue(1.0)
+    win.chk_raster_stack.setChecked(True)
+    win.stack_range.setValue(0.7)
+    win.stack_step.setValue(0.02)
+    win._run_raster()
+    cfg = captured['cfg']
+    assert cfg.stack is True
+    assert cfg.stack_range_mm == pytest.approx(0.7)
+    assert cfg.stack_step_mm == pytest.approx(0.02)


### PR DESCRIPTION
## Summary
- add tests ensuring autofocus, capture, and focus stack run in order and skip stack when disabled
- verify UI raster configuration populates stack parameters

## Testing
- `pytest microstage_app/tests/test_raster.py::test_raster_focus_stack_order microstage_app/tests/test_raster.py::test_raster_no_stack microstage_app/tests/test_ui_raster_modes.py::test_raster_stack_config -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1941130748324b4a5bb13feb4e60d