### PR TITLE
Handle busy serial ports and ensure stage dialog lists current port

### DIFF
--- a/microstage_app/devices/stage_marlin.py
+++ b/microstage_app/devices/stage_marlin.py
@@ -29,6 +29,10 @@ def list_marlin_ports(time_wait: float = 2.0, machine_name: str = EXPECTED_MACHI
                 if machine_name and machine_name.lower() not in resp:
                     continue
                 matches.append(p.device)
+        except serial.SerialException as e:
+            if "device or resource busy" in str(e).lower():
+                matches.append(p.device)
+            continue
         except Exception:
             continue
     return matches

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1202,7 +1202,12 @@ class MainWindow(QtWidgets.QMainWindow):
         lay = QtWidgets.QVBoxLayout(dlg)
         lst = QtWidgets.QListWidget()
         lay.addWidget(lst)
-        for port in list_marlin_ports():
+        ports = list(list_marlin_ports())
+        if self.stage and getattr(self.stage, "port", None):
+            cur = self.stage.port
+            if cur not in ports:
+                ports.insert(0, cur)
+        for port in ports:
             item = QtWidgets.QListWidgetItem(port)
             item.setData(QtCore.Qt.UserRole, port)
             if self.stage and getattr(self.stage, "port", None) == port:


### PR DESCRIPTION
## Summary
- Return busy serial ports from `list_marlin_ports` so already-open devices still appear in the UI
- Always include the currently-connected stage when showing the stage selection dialog

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b19857a118832490380e6eee6bca1b