### PR TITLE
Fix lens loading loop

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -420,7 +420,7 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 # legacy flat value
                 lens = Lens(name, float(cfg))
-        self.lenses[name] = lens
+            self.lenses[name] = lens
         cur_name = self.profiles.get('measurement.current_lens', '10x', expected_type=str)
         self.current_lens = self.lenses.get(cur_name)
         if not self.current_lens:


### PR DESCRIPTION
## Summary
- ensure every profile lens entry populates `self.lenses`

## Testing
- `python3 - <<'PY'
import os, sys, types
from pathlib import Path
cv2_stub = types.SimpleNamespace(RETR_EXTERNAL=0,CHAIN_APPROX_SIMPLE=0,
    findContours=lambda *a, **k:([], None),
    moments=lambda *a, **k:{"m00":0,"m10":0,"m01":0})
sys.modules.setdefault("cv2", cv2_stub)
from microstage_app.control.profiles import Profiles
from microstage_app.ui.main_window import MainWindow
from microstage_app.analysis import Lens
from PySide6 import QtWidgets
os.environ["QT_QPA_PLATFORM"]="offscreen"
profile_path = Path('temp_profiles.yaml')
orig_path = Profiles.PATH
Profiles.PATH = str(profile_path)
if profile_path.exists(): profile_path.unlink()
profiles = Profiles.load_or_create()
profiles.set("measurement.lenses", {"10x":1.0, "20x":0.5})
profiles.set("measurement.current_lens", "10x")
profiles.save()
app = QtWidgets.QApplication([])
mw = MainWindow()
print('Before:', sorted(mw.lenses.keys()))
mw.lenses['30x']=Lens('30x',0.3)
mw.profiles.set("measurement.lenses.30x", mw.lenses['30x'].um_per_px)
mw.profiles.save()
mw2 = MainWindow()
print('After:', sorted(mw2.lenses.keys()))
Profiles.PATH = orig_path
profile_path.unlink()
app.quit()
PY`
- `pytest -q` *(fails: AttributeError: <class 'microstage_app.ui.main_window.MainWindow'> has no attribute '_update_stage_buttons')*

------
https://chatgpt.com/codex/tasks/task_e_68b19a811fe08324ba021ab4499ad3ec