### PR TITLE
Enable optional CUDA capture path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
  or run the helper script `scripts/install_libgl1.sh`. For headless setups,
   you may instead install `opencv-python-headless` to avoid the `libGL`
   dependency.
+
+   Optional GPU acceleration for captures is available when OpenCV is built
+   with CUDA modules. The application automatically detects CUDA support and
+   falls back to CPU processing if the modules are absent.
 3. Install the **ToupTek / Toupcam SDK for Windows**. Copy the `toupcam.dll` (x64) next to `main.py` (or put it in your PATH).
    The SDK usually ships `toupcam.py` and examples; this app will auto-import if present.
    Basic USB webcams are also supported via OpenCV's ``VideoCapture`` and do not
@@ -49,6 +53,8 @@ will be enabled.
 - Robustness: hot-plug (to be expanded), watchdogs (to be expanded), structured logs.
 - Scripting: run custom recipes from `microstage_app/scripts/` with a safe API.
 - Validated capture directory/filename fields with optional auto-numbering to prevent overwrites.
+- Optional CUDA acceleration for capture and scale-bar drawing when OpenCV is
+  built with CUDA; falls back to CPU otherwise.
 
 ## Capture directory & file naming
 

--- a/tests/test_capture_cuda.py
+++ b/tests/test_capture_cuda.py
@@ -1,0 +1,88 @@
+import sys
+from pathlib import Path
+import types
+
+import numpy as np
+import cv2
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from microstage_app.ui import main_window
+
+
+def _run_capture(monkeypatch, frame, gpu):
+    mw = main_window.MainWindow.__new__(main_window.MainWindow)
+    mw.stage = types.SimpleNamespace(wait_for_moves=lambda: None, get_position=lambda: {})
+    saved = {}
+    def fake_save(img, **kwargs):
+        saved['img'] = img
+    mw.image_writer = types.SimpleNamespace(save_single=fake_save)
+    mw.chk_scale_bar = types.SimpleNamespace(isChecked=lambda: True)
+    mw.current_lens = types.SimpleNamespace(um_per_px=1.0, name='lens')
+    mw.capture_dir = '/tmp'
+    mw.capture_name = 'test'
+    mw.auto_number = False
+    mw.capture_format = 'png'
+
+    if gpu:
+        class FakeGpuMat:
+            def __init__(self, mat=None):
+                self.mat = mat
+            def upload(self, arr):
+                self.mat = arr.copy()
+            def download(self):
+                return self.mat
+            def size(self):
+                return (self.mat.shape[1], self.mat.shape[0])
+            def rowRange(self, y1, y2):
+                return FakeGpuMat(self.mat[y1:y2])
+            def colRange(self, x1, x2):
+                return FakeGpuMat(self.mat[:, x1:x2])
+            def setTo(self, color):
+                self.mat[...] = color
+        def fake_cvtColor(gm, code):
+            out = FakeGpuMat()
+            out.mat = cv2.cvtColor(gm.mat, code)
+            return out
+        monkeypatch.setattr(cv2, 'cuda_GpuMat', FakeGpuMat)
+        monkeypatch.setattr(cv2.cuda, 'getCudaEnabledDeviceCount', lambda: 1)
+        monkeypatch.setattr(cv2.cuda, 'cvtColor', fake_cvtColor, raising=False)
+    else:
+        monkeypatch.setattr(cv2.cuda, 'getCudaEnabledDeviceCount', lambda: 0)
+
+    def fake_snap(use_cuda=False):
+        assert use_cuda == gpu
+        if use_cuda:
+            gm = cv2.cuda_GpuMat()
+            gm.upload(frame)
+            gm = cv2.cuda.cvtColor(gm, cv2.COLOR_BGR2RGB)
+            return gm.download()
+        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    mw.camera = types.SimpleNamespace(name=lambda: 'cam', snap=fake_snap,
+                                      get_exposure_ms=lambda: None, get_gain=lambda: None)
+
+    class DummySignal:
+        def connect(self, cb):
+            cb(True, None)
+    class DummyWorker:
+        finished = DummySignal()
+    def fake_run_async(func):
+        func()
+        return None, DummyWorker()
+    monkeypatch.setattr(main_window, 'run_async', fake_run_async)
+
+    mw._capture()
+    return saved['img']
+
+
+def test_capture_cpu(monkeypatch):
+    frame = np.array([[[0, 0, 255], [255, 0, 0]]], dtype=np.uint8)
+    out = _run_capture(monkeypatch, frame, gpu=False)
+    assert np.array_equal(out, cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+
+
+def test_capture_gpu(monkeypatch):
+    frame = np.array([[[0, 0, 255], [255, 0, 0]]], dtype=np.uint8)
+    out = _run_capture(monkeypatch, frame, gpu=True)
+    assert np.array_equal(out, cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))


### PR DESCRIPTION
## Summary
- Detect CUDA availability for camera captures and scale-bar rendering
- Route Toupcam snapshots and scale-bar drawing through OpenCV CUDA when available, with CPU fallback
- Document optional GPU acceleration and add tests for GPU vs CPU capture paths

## Testing
- `python -m pytest tests/test_capture_cuda.py tests/test_preview_cuda.py -q`
- `python -m pytest -q` *(fails: 8 failed, 103 passed, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b19c9c1ba483249a6bf164587b2dcb