### PR TITLE
Refactor lens profile storage

### DIFF
--- a/microstage_app/tests/test_lens_profile_persistence.py
+++ b/microstage_app/tests/test_lens_profile_persistence.py
@@ -1,0 +1,43 @@
+import os
+import yaml
+import pytest
+from PySide6 import QtWidgets
+
+import microstage_app.ui.main_window as mw
+from microstage_app.control.profiles import Profiles
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    yield app
+
+
+def test_lens_profile_persistence(monkeypatch, tmp_path, qt_app):
+    pfile = tmp_path / "profiles.yaml"
+    monkeypatch.setattr(Profiles, "PATH", str(pfile))
+    monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    # simulate dialogs
+    monkeypatch.setattr(QtWidgets.QInputDialog, "getText", staticmethod(lambda *a, **k: ("15x", True)))
+    monkeypatch.setattr(QtWidgets.QInputDialog, "getDouble", staticmethod(lambda *a, **k: (200.0, True)))
+
+    win1 = mw.MainWindow()
+    qt_app.processEvents()
+    win1._add_lens()
+    qt_app.processEvents()
+    win1._on_calibration_done(100.0)
+    qt_app.processEvents()
+    win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
+
+    data = yaml.safe_load(pfile.read_text())
+    assert data["measurement"]["lenses"]["15x"]["um_per_px"] == pytest.approx(2.0)
+    assert data["measurement"]["lenses"]["15x"]["calibrations"]["default"] == pytest.approx(2.0)
+
+    win2 = mw.MainWindow()
+    lens = win2.lenses["15x"]
+    assert lens.um_per_px == pytest.approx(2.0)
+    assert lens.calibrations["default"] == pytest.approx(2.0)
+    win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()

--- a/microstage_app/tests/test_profiles_migration.py
+++ b/microstage_app/tests/test_profiles_migration.py
@@ -3,7 +3,7 @@ from microstage_app.control.profiles import Profiles, DEFAULTS
 
 
 def test_profiles_migration(monkeypatch, tmp_path):
-    old = {'camera': {'gain': 2.0}}
+    old = {'camera': {'gain': 2.0}, 'measurement': {'lenses': {'10x': 1.23}}}
     pfile = tmp_path / 'profiles.yaml'
     pfile.write_text(yaml.safe_dump(old))
     monkeypatch.setattr(Profiles, 'PATH', str(pfile))
@@ -11,6 +11,10 @@ def test_profiles_migration(monkeypatch, tmp_path):
     assert p.data['version'] == Profiles.VERSION
     assert p.data['camera']['gain'] == 2.0
     assert p.data['camera']['exposure_ms'] == DEFAULTS['camera']['exposure_ms']
+    assert p.data['measurement']['lenses']['10x']['um_per_px'] == 1.23
+    assert p.data['measurement']['lenses']['10x']['calibrations'] == {}
     saved = yaml.safe_load(pfile.read_text())
     assert saved['version'] == Profiles.VERSION
     assert 'capture' in saved
+    assert saved['measurement']['lenses']['10x']['um_per_px'] == 1.23
+    assert saved['measurement']['lenses']['10x']['calibrations'] == {}


### PR DESCRIPTION
## Summary
- Store preset lens profiles as dicts with `um_per_px` and nested `calibrations`
- Persist lens changes and calibration results to the updated profile structure
- Test that lens profiles and calibrations migrate, serialize and reload correctly

## Testing
- `pytest microstage_app/tests/test_profiles_migration.py microstage_app/tests/test_lens_profile_persistence.py microstage_app/tests/test_resolution_calibration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1a4392d54832495035fd10759fcb6