### PR TITLE
Use process CPU percentage in SystemMonitorTab

### DIFF
--- a/microstage_app/ui/system_monitor_tab.py
+++ b/microstage_app/ui/system_monitor_tab.py
@@ -28,6 +28,8 @@ class SystemMonitorTab(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout(self)
 
         # CPU widgets
+        self.proc = psutil.Process()
+        self.proc.cpu_percent(None)
         self.cpu_label = QtWidgets.QLabel("CPU Usage: 0%")
         self.cpu_bar = QtWidgets.QProgressBar()
         self.cpu_bar.setRange(0, 100)
@@ -73,7 +75,7 @@ class SystemMonitorTab(QtWidgets.QWidget):
 
     # ------------------------------------------------------------------
     def update_metrics(self) -> None:
-        cpu = psutil.cpu_percent()
+        cpu = self.proc.cpu_percent(None) / psutil.cpu_count()
         self.cpu_bar.setValue(int(cpu))
         self.cpu_label.setText(f"CPU Usage: {cpu:.1f}%")
 


### PR DESCRIPTION
## Summary
- monitor CPU usage of this process using psutil.Process
- initialize Process instance in `SystemMonitorTab` and prime readings
- compute CPU percentage per core and update CPU progress bar and label

## Testing
- `python -m py_compile microstage_app/ui/system_monitor_tab.py`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c187fe7c8324a0f3655473bc3f2b