### PR TITLE
Add tooltip context helper for all widgets

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1,6 +1,7 @@
 from PySide6 import QtWidgets, QtCore, QtGui
 
 from .system_monitor_tab import SystemMonitorTab
+from .tooltips import apply_tooltip_context
 
 import numpy as np
 import cv2
@@ -517,6 +518,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._update_leveling_method()
         # ensure raster UI reflects current mode after loading profiles
         self._update_raster_mode()
+
+        # install right-click tooltip handlers for all inputs/buttons
+        apply_tooltip_context(self)
 
         # mirror logs to the in-app log pane
         LOG.message.connect(self._append_log)

--- a/microstage_app/ui/system_monitor_tab.py
+++ b/microstage_app/ui/system_monitor_tab.py
@@ -1,5 +1,7 @@
 from PySide6 import QtWidgets, QtCore
 
+from .tooltips import apply_tooltip_context
+
 import logging
 import psutil
 
@@ -68,6 +70,9 @@ class SystemMonitorTab(QtWidgets.QWidget):
         self.timer = QtCore.QTimer(self)
         self.timer.setInterval(1000)
         self.timer.timeout.connect(self.update_metrics)
+
+        # ensure right-click tooltips for any interactive widgets
+        apply_tooltip_context(self)
 
     # ------------------------------------------------------------------
     def start(self) -> None:

--- a/microstage_app/ui/tooltips.py
+++ b/microstage_app/ui/tooltips.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from PySide6 import QtWidgets, QtCore
+
+
+class _TooltipContextFilter(QtCore.QObject):
+    """Event filter showing a widget's tooltip on context menu events."""
+
+    def eventFilter(self, obj: QtCore.QObject, event: QtCore.QEvent) -> bool:  # type: ignore[override]
+        if event.type() == QtCore.QEvent.ContextMenu:
+            tip = obj.toolTip() if hasattr(obj, "toolTip") else ""
+            if tip:
+                QtWidgets.QToolTip.showText(event.globalPos(), tip, obj)  # type: ignore[arg-type]
+                return True
+        return super().eventFilter(obj, event)
+
+
+def install_tooltip_context(widget: QtWidgets.QWidget) -> None:
+    """Install context-menu tooltip behavior on *widget*."""
+    filt = _TooltipContextFilter(widget)
+    widget.installEventFilter(filt)
+    # Store reference to avoid garbage collection
+    widget._tooltip_ctx_filter = filt  # type: ignore[attr-defined]
+
+
+_INPUT_WIDGET_TYPES = (
+    QtWidgets.QLineEdit,
+    QtWidgets.QComboBox,
+    QtWidgets.QAbstractSpinBox,
+    QtWidgets.QSlider,
+    QtWidgets.QAbstractButton,
+)
+
+
+def apply_tooltip_context(root: QtWidgets.QWidget) -> None:
+    """Apply tooltip context behavior to all input widgets under *root*."""
+    for t in _INPUT_WIDGET_TYPES:
+        for w in root.findChildren(t):
+            install_tooltip_context(w)


### PR DESCRIPTION
## Summary
- show widget tooltips on context-menu events with a reusable event filter
- apply the tooltip helper to main window and system monitor widgets

## Testing
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c0a76988324a5c317f9ffcadfb5