### PR TITLE
Add exposure-aware delay to initial focus stack iteration

### DIFF
--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -209,7 +209,16 @@ class AutoFocus:
             move = dz - cumulative
             self.stage.move_relative(dz=move, feed_mm_per_min=feed_mm_per_min)
             self.stage.wait_for_moves()
-            time.sleep(0.02)
+            if i == 0:
+                time.sleep(0.5)
+            delay = 0.02
+            get_exp = getattr(self.camera, "get_exposure_ms", None)
+            if get_exp:
+                try:
+                    delay = max(delay, float(get_exp()) / 1000.0)
+                except Exception:
+                    pass
+            time.sleep(delay)
             img = self.camera.snap()
             if img is None:
                 if metric:

--- a/microstage_app/tests/test_autofocus.py
+++ b/microstage_app/tests/test_autofocus.py
@@ -12,6 +12,8 @@ class StageMock:
         self.moves.append((dz, feed_mm_per_min))
     def wait_for_moves(self):
         pass
+    def get_position(self):
+        return (0.0, 0.0, self.z)
 
 class CameraMock:
     def snap(self):
@@ -115,3 +117,30 @@ def test_metric_value_invalid_channels_raise():
     bad = np.zeros((4, 4, 2), dtype=np.uint8)
     with pytest.raises(ValueError):
         af.metric_value(bad, FocusMetric.LAPLACIAN)
+
+
+def test_focus_stack_initial_delay(monkeypatch, tmp_path):
+    stage = StageMock()
+
+    class Cam(CameraMock):
+        def get_exposure_ms(self):
+            return 30
+
+    class WriterMock:
+        def __init__(self, run_dir):
+            self.run_dir = run_dir
+
+        def save_single(self, *args, **kwargs):
+            pass
+
+    cam = Cam()
+    writer = WriterMock(str(tmp_path))
+    af_inst = AutoFocus(stage, cam)
+    sleeps = []
+
+    monkeypatch.setattr(af.time, "sleep", lambda s: sleeps.append(s))
+
+    af_inst.focus_stack(range_mm=0.05, step_mm=0.05, writer=writer)
+
+    assert sleeps[0] == pytest.approx(0.5)
+    assert sleeps[1:] == [pytest.approx(0.03)] * 3


### PR DESCRIPTION
## Summary
- add 0.5s pause before first focus-stack capture and scale subsequent waits by camera exposure
- cover new autofocus delay logic with unit test

## Testing
- `pytest` *(fails: 26 errors during collection)*
- `pytest microstage_app/tests/test_autofocus.py -k test_focus_stack_initial_delay -q`

------
https://chatgpt.com/codex/tasks/task_e_68c71d3f5d4883248ecb8ed04d29cfe4