### PR TITLE
Name focus stack output by capture

### DIFF
--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -159,10 +159,12 @@ class AutoFocus:
         writer: ImageWriter,
         *,
         directory: Optional[str] = None,
+        base_name: str = "",
         metric: Optional[FocusMetric] = None,
         feed_mm_per_min: float = 240,
         fmt: str = "png",
         lens_name: Optional[str] = None,
+        use_mm: bool = False,
     ) -> Optional[int]:
         """Sweep Z over ``range_mm`` in ``step_mm`` increments and capture frames.
 
@@ -178,6 +180,9 @@ class AutoFocus:
         directory : str, optional
             Directory in which to save images. If ``None``, ``writer.run_dir``
             is used.
+        base_name : str, optional
+            Base name used when saving each frame. If empty, frames are saved
+            using only the depth index or depth value.
         metric : FocusMetric, optional
             If provided, compute the metric for each frame and return the index
             of the sharpest frame.
@@ -187,6 +192,9 @@ class AutoFocus:
             Image format passed to :meth:`ImageWriter.save_single`.
         lens_name : str, optional
             Name of the lens used for capture; included in image metadata.
+        use_mm : bool, optional
+            If ``True``, use the depth value in millimeters when constructing
+            filenames; otherwise use a simple depth index.
 
         Returns
         -------
@@ -230,10 +238,15 @@ class AutoFocus:
                 "Position": pos,
                 "Lens": lens_name,
             }
+            if use_mm:
+                base = f"{dz:.4f}mm"
+            else:
+                base = f"{i:04d}"
+            fname = f"{base_name}_{base}" if base_name else base
             writer.save_single(
                 img,
                 directory=directory,
-                filename=f"{i:04d}",
+                filename=fname,
                 auto_number=False,
                 fmt=fmt,
                 metadata=metadata,

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2375,7 +2375,8 @@ class MainWindow(QtWidgets.QMainWindow):
         rng = float(self.stack_range.value())
         feed = self.feedz_spin.value()
         writer = ImageWriter(self.capture_dir)
-        stack_dir = writer.run_dir
+        stack_dir = os.path.join(self.capture_dir, self.capture_name)
+        os.makedirs(stack_dir, exist_ok=True)
         self._last_stack_dir = stack_dir
         self.btn_focus_stack.setEnabled(False)
 
@@ -2386,6 +2387,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 step,
                 writer,
                 directory=stack_dir,
+                base_name=self.capture_name,
                 metric=FocusMetric.LAPLACIAN,
                 feed_mm_per_min=feed,
                 fmt=self.capture_format,


### PR DESCRIPTION
## Summary
- save focus stack frames under `<capture_dir>/<capture_name>`
- pass capture name as base name to `AutoFocus.focus_stack`
- allow `AutoFocus.focus_stack` to name frames by index or depth

## Testing
- `pytest microstage_app/tests/test_autofocus.py::test_focus_stack_initial_delay -q`
- `pytest microstage_app/tests/test_raster.py::test_raster_focus_stack_order -q`
- `pytest` *(fails: 8 failed, 109 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c71e65906483248b6ba36f3c628660