### PR TITLE
Refresh scale bar when lens changes

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1133,6 +1133,13 @@ class MainWindow(QtWidgets.QMainWindow):
             lens = Lens(name, 1.0)
             self.lenses[name] = lens
         self.current_lens = lens
+        # Update the live preview scale bar immediately so that both the
+        # on-screen view and any subsequent captures use the latest
+        # calibration. This also refreshes cached scale values used when
+        # drawing the scale bar on captured images.
+        self.measure_view.set_scale_bar(
+            self.chk_scale_bar.isChecked(), lens.um_per_px
+        )
         self.profiles.set('measurement.current_lens', name)
         self.profiles.set(f'measurement.lenses.{name}.um_per_px', lens.um_per_px)
         self.profiles.save()


### PR DESCRIPTION
## Summary
- update scale bar when switching lenses so captured images use new calibration

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c7202090bc832482820b1cab8e6e79