### PR TITLE
Add optional EDF fusion for focus stacks

### DIFF
--- a/microstage_app/analysis/__init__.py
+++ b/microstage_app/analysis/__init__.py
@@ -2,6 +2,7 @@
 
 from .measure import centroid, find_contours, measure_area, measure_distance
 from .lenses import Lens
+from .edf import fuse_stack
 
 __all__ = [
     "measure_distance",
@@ -9,4 +10,5 @@ __all__ = [
     "find_contours",
     "centroid",
     "Lens",
+    "fuse_stack",
 ]

--- a/microstage_app/analysis/edf.py
+++ b/microstage_app/analysis/edf.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from typing import List
+import numpy as np
+
+try:
+    import microstage_edf_gpu as _edf_impl
+except Exception as exc:  # pragma: no cover - handled at runtime
+    _edf_impl = None
+    _edf_import_error = exc
+else:
+    _edf_import_error = None
+
+
+def fuse_stack(images: List[np.ndarray], use_cuda: bool = True) -> np.ndarray:
+    """Fuse a stack of images into a single sharp image.
+
+    Parameters
+    ----------
+    images : list of numpy.ndarray
+        Sequence of images forming the focus stack. Each image may be either
+        grayscale or BGR. All images should share the same dimensions.
+    use_cuda : bool, optional
+        If ``True`` (default), attempt to use CUDA acceleration when available.
+
+    Returns
+    -------
+    numpy.ndarray
+        The fused image as an unsigned 8-bit array in BGR order.
+    """
+    if _edf_impl is None:  # pragma: no cover - import failure at runtime
+        raise ImportError("microstage_edf_gpu could not be imported") from _edf_import_error
+
+    fused, _ = _edf_impl.fuse_stack(
+        images,
+        color_mode="lab_l_only",
+        focus="tenengrad",
+        levels=5,
+        sobel_ksize=3,
+        linear_fusion=False,
+        use_sat_weight=False,
+        sat_gamma=1.0,
+        clahe_l=False,
+        clahe_clip=2.0,
+        clahe_tiles=8,
+        use_gpu=use_cuda,
+    )
+    return fused

--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -165,6 +165,7 @@ class AutoFocus:
         fmt: str = "png",
         lens_name: Optional[str] = None,
         use_mm: bool = False,
+        fuse_edf: bool = False,
     ) -> Optional[int]:
         """Sweep Z over ``range_mm`` in ``step_mm`` increments and capture frames.
 
@@ -213,6 +214,7 @@ class AutoFocus:
         zs = [(-steps + i) * step_mm for i in range(2 * steps + 1)]
         cumulative = 0.0
         metrics = []
+        images = [] if fuse_edf else None
         for i, dz in enumerate(zs):
             move = dz - cumulative
             self.stage.move_relative(dz=move, feed_mm_per_min=feed_mm_per_min)
@@ -232,6 +234,11 @@ class AutoFocus:
                 if metric:
                     metrics.append(float("-inf"))
                 continue
+            if images is not None:
+                if img.ndim == 3:
+                    images.append(cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+                else:
+                    images.append(img)
             pos = self.stage.get_position()
             metadata = {
                 "Camera": self.camera.name(),
@@ -258,6 +265,26 @@ class AutoFocus:
         # Return to starting position
         self.stage.move_relative(dz=-cumulative, feed_mm_per_min=feed_mm_per_min)
         self.stage.wait_for_moves()
+
+        if images:
+            from ..analysis.edf import fuse_stack as _edf_fuse_stack
+
+            fused = _edf_fuse_stack(images, use_cuda=True)
+            if fused.ndim == 3:
+                fused = cv2.cvtColor(fused, cv2.COLOR_BGR2RGB)
+            fname = f"{base_name}_edf" if base_name else "fused"
+            metadata = {
+                "Camera": self.camera.name(),
+                "Lens": lens_name,
+            }
+            writer.save_single(
+                fused,
+                directory=directory,
+                filename=fname,
+                auto_number=False,
+                fmt=fmt,
+                metadata=metadata,
+            )
 
         if metric and metrics:
             best_idx = int(np.argmax(metrics))

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -654,10 +654,12 @@ class MainWindow(QtWidgets.QMainWindow):
         s = QtWidgets.QGridLayout(stack_box)
         self.stack_range = QtWidgets.QDoubleSpinBox(); self.stack_range.setRange(0.01, 5.0); self.stack_range.setValue(0.5)
         self.stack_step = QtWidgets.QDoubleSpinBox(); self.stack_step.setDecimals(6); self.stack_step.setRange(0.000001, 1.0); self.stack_step.setSingleStep(0.000001); self.stack_step.setValue(0.01)
+        self.chk_edf = QtWidgets.QCheckBox("EDF Fusion")
         self.btn_focus_stack = QtWidgets.QPushButton("Run Focus Stack")
         s.addWidget(QtWidgets.QLabel("Range (mm):"), 0, 0); s.addWidget(self.stack_range, 0, 1)
         s.addWidget(QtWidgets.QLabel("Step (mm):"), 1, 0); s.addWidget(self.stack_step, 1, 1)
-        s.addWidget(self.btn_focus_stack, 2, 0, 1, 2)
+        s.addWidget(self.chk_edf, 2, 0, 1, 2)
+        s.addWidget(self.btn_focus_stack, 3, 0, 1, 2)
 
         af_box.setMaximumWidth(240)
         stack_box.setMaximumWidth(240)
@@ -2401,6 +2403,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 feed_mm_per_min=feed,
                 fmt=self.capture_format,
                 lens_name=self.current_lens.name,
+                fuse_edf=self.chk_edf.isChecked(),
             )
 
         log(f"Focus stack: range={rng} step={step} dir={stack_dir}")


### PR DESCRIPTION
## Summary
- add `analysis.edf` module wrapping GPU-enabled EDF fusion
- allow `AutoFocus.focus_stack` to fuse captured stacks and save a composite image
- expose EDF fusion checkbox in the UI focus stack controls

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7233e34208324a19735253a51cf32