### PR TITLE
Log CUDA usage for heavy operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,15 @@ and a **RisingCam E3ISPM** camera (ToupTek OEM) via the vendor SDK. Includes **a
   or run the helper script `scripts/install_libgl1.sh`. For headless setups,
   you may instead install `opencv-python-headless` to avoid the `libGL`
   dependency. The system monitor tab uses `psutil`; NVIDIA GPU metrics also
-  require the optional `nvidia-ml-py3` package and appropriate drivers.
+  require the optional `nvidia-ml-py3` package and appropriate drivers. When
+  no GPU is present, the tab simply shows a notice so the app continues to
+  run normally.
 
-   Optional GPU acceleration for captures and autofocus metrics is available
-   when OpenCV is built with CUDA modules. The application automatically
-   detects CUDA support and falls back to CPU processing if the modules are
-   absent.
+   Optional GPU acceleration for captures, autofocus metrics, and scale-bar
+   drawing is available when OpenCV is built with CUDA modules. The
+   application automatically detects CUDA support, falls back to CPU
+   processing if the modules are absent, and logs which path is chosen to aid
+   troubleshooting.
 3. Install the **ToupTek / Toupcam SDK for Windows**. Copy the `toupcam.dll` (x64) next to `main.py` (or put it in your PATH).
    The SDK usually ships `toupcam.py` and examples; this app will auto-import if present.
    Basic USB webcams are also supported via OpenCV's ``VideoCapture`` and do not
@@ -56,9 +59,10 @@ will be enabled.
 - Scripting: run custom recipes from `microstage_app/scripts/` with a safe API.
 - Validated capture directory/filename fields with optional auto-numbering to prevent overwrites.
 - Optional CUDA acceleration for capture, autofocus metrics, and scale-bar
-  drawing when OpenCV is built with CUDA; falls back to CPU otherwise.
+  drawing when OpenCV is built with CUDA; falls back to CPU otherwise and
+  logs the active path.
 - System monitor tab displaying CPU load and, when supported, NVIDIA GPU
-  utilization via NVML.
+  utilization via NVML, with a message shown when GPUs are unavailable.
 
 ## Capture directory & file naming
 

--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -1,12 +1,27 @@
 from enum import Enum
 import math
 import os
-import numpy as np
-import cv2
 import time
+import logging
 from typing import Optional
 
+import numpy as np
+import cv2
+
 from ..io.storage import ImageWriter
+
+logger = logging.getLogger(__name__)
+
+try:
+    _HAS_CUDA = (
+        hasattr(cv2, "cuda")
+        and hasattr(cv2.cuda, "getCudaEnabledDeviceCount")
+        and cv2.cuda.getCudaEnabledDeviceCount() > 0
+    )
+except Exception:
+    _HAS_CUDA = False
+
+logger.info("Autofocus metrics using %s", "CUDA" if _HAS_CUDA else "CPU")
 
 class FocusMetric(str, Enum):
     LAPLACIAN = "LaplacianVar"
@@ -45,14 +60,12 @@ def metric_value(img, metric: FocusMetric):
     else:
         raise ValueError(f"Unsupported image shape: {img.shape}")
 
-    use_cuda = (
-        hasattr(cv2, "cuda")
-        and hasattr(cv2.cuda, "getCudaEnabledDeviceCount")
-        and cv2.cuda.getCudaEnabledDeviceCount() > 0
+    logger.debug(
+        "Computing %s metric on %s", metric, "CUDA" if _HAS_CUDA else "CPU"
     )
 
     if metric == FocusMetric.LAPLACIAN:
-        if use_cuda:
+        if _HAS_CUDA:
             gpu_mat = cv2.cuda_GpuMat()
             gpu_mat.upload(gray)
             # Assume 8-bit input; fallback will handle other types
@@ -65,7 +78,7 @@ def metric_value(img, metric: FocusMetric):
             lap = cv2.Laplacian(gray, cv2.CV_64F)
         return float(lap.var())
     elif metric == FocusMetric.TENENGRAD:
-        if use_cuda:
+        if _HAS_CUDA:
             gpu_mat = cv2.cuda_GpuMat()
             gpu_mat.upload(gray)
             sobel_x = cv2.cuda.createSobelFilter(

--- a/microstage_app/utils/img.py
+++ b/microstage_app/utils/img.py
@@ -1,5 +1,6 @@
 import math
 import subprocess
+import logging
 
 import numpy as np
 from PySide6 import QtGui
@@ -13,6 +14,7 @@ TEXT_SCALE = 4  # font size multiplier
 
 
 _scale_font_cache = None
+logger = logging.getLogger(__name__)
 
 
 def _load_scale_font() -> ImageFont.FreeTypeFont:
@@ -58,6 +60,10 @@ def _has_cuda() -> bool:
         return cv2.cuda.getCudaEnabledDeviceCount() > 0
     except Exception:
         return False
+
+
+_HAS_CUDA = _has_cuda()
+logger.info("Scale-bar drawing using %s", "CUDA" if _HAS_CUDA else "CPU")
 
 
 def _draw_scale_bar_cpu(img: np.ndarray, um_per_px: float,
@@ -137,9 +143,12 @@ def draw_scale_bar(img, um_per_px: float):
     if um_per_px <= 0:
         return img if isinstance(img, np.ndarray) else img.download()
 
-    has_cuda = _has_cuda()
+    logger.debug(
+        "draw_scale_bar using %s path",
+        "CUDA" if _HAS_CUDA and isinstance(img, cv2.cuda_GpuMat) else "CPU",
+    )
 
-    if has_cuda and isinstance(img, cv2.cuda_GpuMat):
+    if _HAS_CUDA and isinstance(img, cv2.cuda_GpuMat):
         w, h = img.size()
         h = int(h)
         w = int(w)
@@ -173,7 +182,7 @@ def draw_scale_bar(img, um_per_px: float):
 
     if isinstance(img, np.ndarray):
         if img.ndim == 2:
-            if has_cuda:
+            if _HAS_CUDA:
                 try:
                     gm = cv2.cuda_GpuMat()
                     gm.upload(img)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ scipy>=1.11
 ome-types>=0.5
 Pillow>=11.0
 psutil>=5.9
-# Optional: NVIDIA GPU metrics
+# Optional: NVIDIA GPU metrics for SystemMonitorTab
 nvidia-ml-py3>=7.352.0


### PR DESCRIPTION
## Summary
- clarify optional nvidia-ml-py3 GPU support in docs and requirements
- log whether CUDA paths are used for autofocus metrics
- log whether CUDA paths are used for scale-bar drawing

## Testing
- `pytest` *(fails: 21 failed, 86 passed, 6 warnings, 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c724c0834083249d5e86befd45a6dd