### PR TITLE
Persist autofocus and stack ranges with four-decimal precision

### DIFF
--- a/microstage_app/tests/test_af_spinbox_decimals.py
+++ b/microstage_app/tests/test_af_spinbox_decimals.py
@@ -15,6 +15,8 @@ def qt_app():
 
 def test_af_spinboxes_six_decimals(monkeypatch, qt_app):
     monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_update_stage_buttons", lambda self: None, raising=False)
+    monkeypatch.setattr(mw.MainWindow, "_update_cam_buttons", lambda self: None, raising=False)
 
     win = mw.MainWindow()
 
@@ -48,6 +50,17 @@ def test_af_spinboxes_six_decimals(monkeypatch, qt_app):
         box.setValue(0.0005)
         qt_app.processEvents()
         assert box.text() == "0.000500"
+
+    for box in (win.af_range, win.stack_range):
+        assert box.decimals() == 4
+
+        box.setValue(0.1234)
+        qt_app.processEvents()
+        assert box.text() == "0.1234"
+
+        box.setValue(0.5)
+        qt_app.processEvents()
+        assert box.text() == "0.5000"
 
     for box in (win.stepx_spin, win.stepy_spin, win.stepz_spin):
         box.setValue(0.0005)

--- a/microstage_app/tests/test_ui_field_persistence.py
+++ b/microstage_app/tests/test_ui_field_persistence.py
@@ -23,11 +23,15 @@ def test_ui_field_persistence(monkeypatch, tmp_path, qt_app):
         self.run_dir = str(tmp_path / "runs")
     monkeypatch.setattr(mw.ImageWriter, "__init__", fake_init)
     monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_update_stage_buttons", lambda self: None, raising=False)
+    monkeypatch.setattr(mw.MainWindow, "_update_cam_buttons", lambda self: None, raising=False)
 
     win1 = mw.MainWindow()
     win1.stepx_spin.setValue(1.234)
     win1.feedy_spin.setValue(123.0)
     win1.absz_spin.setValue(9.876)
+    win1.af_range.setValue(0.1234)
+    win1.stack_range.setValue(0.4321)
     qt_app.processEvents()
     win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
 
@@ -35,5 +39,9 @@ def test_ui_field_persistence(monkeypatch, tmp_path, qt_app):
     assert win2.stepx_spin.value() == pytest.approx(1.234)
     assert win2.feedy_spin.value() == pytest.approx(123.0)
     assert win2.absz_spin.value() == pytest.approx(9.876)
+    assert win2.af_range.value() == pytest.approx(0.1234)
+    assert win2.stack_range.value() == pytest.approx(0.4321)
+    assert win2.af_range.text() == "0.1234"
+    assert win2.stack_range.text() == "0.4321"
     win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()
 

--- a/microstage_app/tests/test_ui_settings_persist.py
+++ b/microstage_app/tests/test_ui_settings_persist.py
@@ -26,11 +26,15 @@ def test_ui_settings_persist(monkeypatch, tmp_path, qt_app):
     monkeypatch.setattr(mw.ImageWriter, "__init__", fake_init)
 
     monkeypatch.setattr(mw.MainWindow, "_auto_connect_async", lambda self: None)
+    monkeypatch.setattr(mw.MainWindow, "_update_stage_buttons", lambda self: None, raising=False)
+    monkeypatch.setattr(mw.MainWindow, "_update_cam_buttons", lambda self: None, raising=False)
 
     win1 = mw.MainWindow()
     win1.stepx_spin.setValue(1.234)
     win1.feedy_spin.setValue(45.6)
     win1.absz_spin.setValue(7.89)
+    win1.af_range.setValue(0.2345)
+    win1.stack_range.setValue(0.5432)
     qt_app.processEvents()
     win1.preview_timer.stop(); win1.fps_timer.stop(); win1.close()
 
@@ -38,5 +42,9 @@ def test_ui_settings_persist(monkeypatch, tmp_path, qt_app):
     assert win2.stepx_spin.value() == pytest.approx(1.234)
     assert win2.feedy_spin.value() == pytest.approx(45.6)
     assert win2.absz_spin.value() == pytest.approx(7.89)
+    assert win2.af_range.value() == pytest.approx(0.2345)
+    assert win2.stack_range.value() == pytest.approx(0.5432)
+    assert win2.af_range.text() == "0.2345"
+    assert win2.stack_range.text() == "0.5432"
     win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()
 

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -480,9 +480,23 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # load persisted values; extend _persistent_widgets() to add more fields
         for w, path in self._persistent_widgets():
-            if isinstance(w, QtWidgets.QAbstractSpinBox):
-                val = self.profiles.get(path, w.value(), expected_type=(int, float),
-                                        min_value=w.minimum(), max_value=w.maximum())
+            if isinstance(w, QtWidgets.QDoubleSpinBox):
+                val = self.profiles.get(
+                    path,
+                    w.value(),
+                    expected_type=(int, float),
+                    min_value=w.minimum(),
+                    max_value=w.maximum(),
+                )
+                w.setValue(round(float(val), w.decimals()))
+            elif isinstance(w, QtWidgets.QAbstractSpinBox):
+                val = self.profiles.get(
+                    path,
+                    w.value(),
+                    expected_type=(int, float),
+                    min_value=w.minimum(),
+                    max_value=w.maximum(),
+                )
                 w.setValue(val)
             elif isinstance(w, QtWidgets.QCheckBox):
                 val = self.profiles.get(path, w.isChecked(), expected_type=bool)
@@ -641,7 +655,7 @@ class MainWindow(QtWidgets.QMainWindow):
         af_box = QtWidgets.QGroupBox("Autofocus")
         a = QtWidgets.QGridLayout(af_box)
         self.metric_combo = QtWidgets.QComboBox(); self.metric_combo.addItems([m.value for m in FocusMetric])
-        self.af_range = QtWidgets.QDoubleSpinBox(); self.af_range.setRange(0.01, 5.0); self.af_range.setValue(0.5)
+        self.af_range = QtWidgets.QDoubleSpinBox(); self.af_range.setRange(0.01, 5.0); self.af_range.setDecimals(4); self.af_range.setValue(0.5)
         self.af_coarse = QtWidgets.QDoubleSpinBox(); self.af_coarse.setDecimals(6); self.af_coarse.setRange(0.000001, 1.0); self.af_coarse.setSingleStep(0.000001); self.af_coarse.setValue(0.01)
         self.af_fine = QtWidgets.QDoubleSpinBox(); self.af_fine.setDecimals(6); self.af_fine.setRange(0.0005, 0.2); self.af_fine.setValue(0.002)
         self.btn_autofocus = QtWidgets.QPushButton("Run Autofocus")
@@ -652,7 +666,7 @@ class MainWindow(QtWidgets.QMainWindow):
         a.addWidget(self.btn_autofocus, 4, 0, 1, 2)
         stack_box = QtWidgets.QGroupBox("Focus Stack")
         s = QtWidgets.QGridLayout(stack_box)
-        self.stack_range = QtWidgets.QDoubleSpinBox(); self.stack_range.setRange(0.01, 5.0); self.stack_range.setValue(0.5)
+        self.stack_range = QtWidgets.QDoubleSpinBox(); self.stack_range.setRange(0.01, 5.0); self.stack_range.setDecimals(4); self.stack_range.setValue(0.5)
         self.stack_step = QtWidgets.QDoubleSpinBox(); self.stack_step.setDecimals(6); self.stack_step.setRange(0.000001, 1.0); self.stack_step.setSingleStep(0.000001); self.stack_step.setValue(0.01)
         self.chk_edf = QtWidgets.QCheckBox("EDF Fusion")
         self.btn_focus_stack = QtWidgets.QPushButton("Run Focus Stack")
@@ -2711,6 +2725,9 @@ class MainWindow(QtWidgets.QMainWindow):
             (self.absx_spin, "ui.move.absx"),
             (self.absy_spin, "ui.move.absy"),
             (self.absz_spin, "ui.move.absz"),
+            # autofocus & focus stack
+            (self.af_range, "autofocus.range_mm"),
+            (self.stack_range, "focus_stack.range_mm"),
             # camera settings
             (self.exp_spin, "camera.exposure_ms"),
             (self.autoexp_chk, "camera.auto_exposure"),
@@ -2740,7 +2757,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def closeEvent(self, e: QtGui.QCloseEvent) -> None:
         for w, path in self._persistent_widgets():
-            if isinstance(w, QtWidgets.QAbstractSpinBox):
+            if isinstance(w, QtWidgets.QDoubleSpinBox):
+                val = round(w.value(), w.decimals())
+            elif isinstance(w, QtWidgets.QAbstractSpinBox):
                 val = w.value()
             elif isinstance(w, QtWidgets.QCheckBox):
                 val = w.isChecked()


### PR DESCRIPTION
## Summary
- allow four-decimal input for autofocus and stack range controls
- persist autofocus and stack range values with four-decimal rounding
- add tests for range precision and persistence

## Testing
- `pytest microstage_app/tests/test_af_spinbox_decimals.py microstage_app/tests/test_ui_field_persistence.py microstage_app/tests/test_ui_settings_persist.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7267cf648832480356cb7b71d13d6