### PR TITLE
feat: persist autofocus and focus stack settings

### DIFF
--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -2,7 +2,7 @@ import yaml, os, copy
 from ..utils.log import log
 
 DEFAULTS = {
-    'version': 3,
+    'version': 4,
     'stage': {'feed_mm_s': 50.0 / 60.0, 'settle_ms': 30},
     'camera': {
         'exposure_ms': 10.0,
@@ -49,6 +49,16 @@ DEFAULTS = {
         'step': {'x': 0.1, 'y': 0.1, 'z': 0.1},
         'feed': {'x': 50.0, 'y': 50.0, 'z': 50.0},
         'abs': {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    },
+    # autofocus and focus stack settings
+    'autofocus': {
+        'range_mm': 0.5,
+        'coarse_step_mm': 0.01,
+        'fine_step_mm': 0.002,
+    },
+    'focus_stack': {
+        'range_mm': 0.5,
+        'step_mm': 0.01,
     },
 }
 

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -1114,6 +1114,13 @@ class MainWindow(QtWidgets.QMainWindow):
             bind(getattr(self, f'step{axis}_spin'), f'jog.step.{axis}')
             bind(getattr(self, f'feed{axis}_spin'), f'jog.feed.{axis}')
             bind(getattr(self, f'abs{axis}_spin'), f'jog.abs.{axis}')
+        # autofocus
+        bind(self.af_range, 'autofocus.range_mm')
+        bind(self.af_coarse, 'autofocus.coarse_step_mm')
+        bind(self.af_fine, 'autofocus.fine_step_mm')
+        # focus stacking
+        bind(self.stack_range, 'focus_stack.range_mm')
+        bind(self.stack_step, 'focus_stack.step_mm')
 
     def _on_capture_dir_changed(self, text: str):
         self.capture_dir = text
@@ -2725,9 +2732,6 @@ class MainWindow(QtWidgets.QMainWindow):
             (self.absx_spin, "ui.move.absx"),
             (self.absy_spin, "ui.move.absy"),
             (self.absz_spin, "ui.move.absz"),
-            # autofocus & focus stack
-            (self.af_range, "autofocus.range_mm"),
-            (self.stack_range, "focus_stack.range_mm"),
             # camera settings
             (self.exp_spin, "camera.exposure_ms"),
             (self.autoexp_chk, "camera.auto_exposure"),


### PR DESCRIPTION
## Summary
- add autofocus and focus stack defaults to profile schema
- persist autofocus and focus stack UI fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c728691e888324b91fd1e3aa346ee5