### PR TITLE
Add option to delete focus stack frames after EDF fusion

### DIFF
--- a/microstage_app/control/autofocus.py
+++ b/microstage_app/control/autofocus.py
@@ -3,7 +3,7 @@ import math
 import os
 import time
 import logging
-from typing import Optional
+from typing import Optional, List
 
 import numpy as np
 import cv2
@@ -179,6 +179,7 @@ class AutoFocus:
         lens_name: Optional[str] = None,
         use_mm: bool = False,
         fuse_edf: bool = False,
+        delete_stack: bool = False,
     ) -> Optional[int]:
         """Sweep Z over ``range_mm`` in ``step_mm`` increments and capture frames.
 
@@ -210,6 +211,12 @@ class AutoFocus:
         use_mm : bool, optional
             If ``True``, use the depth value in millimeters when constructing
             filenames; otherwise use a simple depth index.
+        fuse_edf : bool, optional
+            If ``True``, fuse the captured stack using EDF and save the fused
+            image alongside the stack frames.
+        delete_stack : bool, optional
+            When ``True`` and EDF fusion is performed, delete the individual
+            stack frame files after saving the fused image.
 
         Returns
         -------
@@ -229,6 +236,17 @@ class AutoFocus:
         cumulative = 0.0
         metrics = []
         images = [] if fuse_edf else None
+        fmt_lower = (fmt or "bmp").lower()
+        ext_map = {
+            "bmp": "bmp",
+            "tif": "tif",
+            "tiff": "tif",
+            "png": "png",
+            "jpg": "jpg",
+            "jpeg": "jpg",
+        }
+        file_ext = ext_map.get(fmt_lower, "bmp")
+        stack_files: Optional[List[str]] = [] if delete_stack else None
 
         get_exp = getattr(self.camera, "get_exposure_ms", None)
         exposure_s = 0.0
@@ -266,6 +284,8 @@ class AutoFocus:
             else:
                 base = f"{i:04d}"
             fname = f"{base_name}_{base}" if base_name else base
+            if stack_files is not None:
+                stack_files.append(os.path.join(directory, f"{fname}.{file_ext}"))
             writer.save_single(
                 img,
                 directory=directory,
@@ -301,6 +321,16 @@ class AutoFocus:
                 fmt=fmt,
                 metadata=metadata,
             )
+            if stack_files:
+                for frame_path in stack_files:
+                    try:
+                        os.remove(frame_path)
+                    except FileNotFoundError:
+                        continue
+                    except Exception:
+                        logger.warning(
+                            "Failed to delete focus stack frame %s", frame_path, exc_info=True
+                        )
 
         if metric and metrics:
             best_idx = int(np.argmax(metrics))

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -686,11 +686,14 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.stack_step = QtWidgets.QDoubleSpinBox(); self.stack_step.setDecimals(6); self.stack_step.setRange(0.000001, 1.0); self.stack_step.setSingleStep(0.000001); self.stack_step.setValue(0.01)
         self.chk_edf = QtWidgets.QCheckBox("EDF Fusion")
+        self.chk_delete_stack = QtWidgets.QCheckBox("Delete stack images")
+        self.chk_delete_stack.setEnabled(False)
         self.btn_focus_stack = QtWidgets.QPushButton("Run Focus Stack")
         s.addWidget(QtWidgets.QLabel("Half-range (±mm):"), 0, 0); s.addWidget(self.stack_range, 0, 1)
         s.addWidget(QtWidgets.QLabel("Step (mm):"), 1, 0); s.addWidget(self.stack_step, 1, 1)
         s.addWidget(self.chk_edf, 2, 0, 1, 2)
-        s.addWidget(self.btn_focus_stack, 3, 0, 1, 2)
+        s.addWidget(self.chk_delete_stack, 3, 0, 1, 2)
+        s.addWidget(self.btn_focus_stack, 4, 0, 1, 2)
 
         af_box.setMaximumWidth(240)
         stack_box.setMaximumWidth(240)
@@ -1076,6 +1079,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_capture.clicked.connect(self._capture)
         self.chk_reticle.toggled.connect(self.measure_view.set_reticle)
         self.chk_scale_bar.toggled.connect(self._on_scale_bar_toggled)
+        self.chk_edf.toggled.connect(self._on_edf_toggled)
         self.btn_add_lens.clicked.connect(self._add_lens)
         # ensure index is emitted as int for lens change
         self.lens_combo.currentIndexChanged[int].connect(self._on_lens_changed)
@@ -1114,6 +1118,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.autonumber_chk.toggled.connect(self._on_autonumber_toggled)
         self.format_combo.currentTextChanged.connect(self._on_format_changed)
         self.btn_browse_dir.clicked.connect(self._browse_capture_dir)
+
+        self._on_edf_toggled(self.chk_edf.isChecked())
 
         self.act_calibrate.triggered.connect(self._calibrate)
         self.act_ruler.triggered.connect(self._start_ruler)
@@ -1191,6 +1197,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.measure_view.set_scale_bar(checked, self.current_lens.um_per_px)
         self.profiles.set('ui.scale_bar', checked)
         self.profiles.save()
+
+    def _on_edf_toggled(self, checked: bool):
+        self.chk_delete_stack.setEnabled(checked)
+        if not checked:
+            self.chk_delete_stack.setChecked(False)
 
     def _on_lens_changed(self, index: int):
         name = self.lens_combo.itemData(index)
@@ -2523,6 +2534,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 fmt=self.capture_format,
                 lens_name=self.current_lens.name,
                 fuse_edf=self.chk_edf.isChecked(),
+                delete_stack=self.chk_delete_stack.isChecked(),
             )
 
         log(f"Focus stack: half-range={rng} step={step} dir={stack_dir}")

--- a/tests/test_autofocus_delete_stack.py
+++ b/tests/test_autofocus_delete_stack.py
@@ -1,0 +1,73 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "cv2",
+    reason="OpenCV is required to test focus-stack file deletion",
+    exc_type=ImportError,
+)
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from microstage_app.control.autofocus import AutoFocus
+from microstage_app.io.storage import ImageWriter
+
+
+class DummyStage:
+    def __init__(self):
+        self._z = 0.0
+
+    def move_relative(self, dz=0.0, feed_mm_per_min=None):
+        self._z += dz
+
+    def wait_for_moves(self):
+        pass
+
+    def get_position(self):
+        return {"x": 0.0, "y": 0.0, "z": self._z}
+
+
+class DummyCamera:
+    def __init__(self):
+        self._count = 0
+
+    def snap(self):
+        self._count += 1
+        return np.full((8, 8, 3), self._count, dtype=np.uint8)
+
+    def name(self):
+        return "DummyCam"
+
+
+def test_focus_stack_deletes_frames(tmp_path, monkeypatch):
+    stack_dir = tmp_path / "stack"
+    writer = ImageWriter(base_dir=str(tmp_path / "runs"))
+
+    monkeypatch.setattr(
+        "microstage_app.control.autofocus.time.sleep", lambda *args, **kwargs: None
+    )
+
+    def fake_fuse(images, use_cuda=True):
+        assert len(images) == 3
+        return images[0]
+
+    monkeypatch.setattr("microstage_app.analysis.edf.fuse_stack", fake_fuse)
+
+    autofocus = AutoFocus(DummyStage(), DummyCamera())
+    autofocus.focus_stack(
+        range_mm=0.1,
+        step_mm=0.1,
+        writer=writer,
+        directory=str(stack_dir),
+        base_name="stack",
+        fmt="png",
+        fuse_edf=True,
+        delete_stack=True,
+    )
+
+    fused_path = stack_dir / "stack_edf.png"
+    assert fused_path.exists()
+    assert sorted(p.name for p in stack_dir.iterdir()) == ["stack_edf.png"]


### PR DESCRIPTION
## Summary
- add a UI control that allows users to request stack image deletion when EDF fusion is enabled
- propagate the delete option into the autofocus focus_stack workflow and remove captured frames after fusion completes
- add a pytest that verifies only the fused image remains when deletion is requested (skips if OpenCV is unavailable)

## Testing
- pytest tests/test_autofocus_delete_stack.py


------
https://chatgpt.com/codex/tasks/task_e_68c8806211548324855766411c80cb8e