### PR TITLE
Add autofocus settings to raster configuration

### DIFF
--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -48,6 +48,9 @@ class RasterConfig:
     stack: bool = False
     stack_range_mm: float = 0.5
     stack_step_mm: float = 0.01
+    af_range_mm: float = 0.5
+    af_coarse_step_mm: float = 0.01
+    af_fine_step_mm: float = 0.002
 
 class RasterRunner:
     def __init__(
@@ -202,7 +205,12 @@ class RasterRunner:
 
                 if do_af:
                     af = AutoFocus(self.stage, self.camera)
-                    af.coarse_to_fine(metric=FocusMetric.LAPLACIAN)
+                    af.coarse_to_fine(
+                        metric=FocusMetric.LAPLACIAN,
+                        z_range_mm=self.cfg.af_range_mm,
+                        coarse_step_mm=self.cfg.af_coarse_step_mm,
+                        fine_step_mm=self.cfg.af_fine_step_mm,
+                    )
                     time.sleep(1)
 
                 if do_capture:

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -128,13 +128,20 @@ def test_raster_autofocus(monkeypatch):
         def __init__(self, stage, camera):
             pass
         def coarse_to_fine(self, metric=None, **kwargs):
-            called.append(metric)
+            called.append((metric, dict(kwargs)))
             return 0.0
 
     monkeypatch.setattr(raster, "AutoFocus", DummyAF)
     runner = RasterRunner(stage, cam, writer, cfg)
     runner.run()
     assert len(called) == cfg.rows * cfg.cols
+    for metric, kwargs in called:
+        assert metric == raster.FocusMetric.LAPLACIAN
+        assert kwargs == {
+            "z_range_mm": cfg.af_range_mm,
+            "coarse_step_mm": cfg.af_coarse_step_mm,
+            "fine_step_mm": cfg.af_fine_step_mm,
+        }
 
 
 def test_raster_initial_move():

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2592,6 +2592,9 @@ class MainWindow(QtWidgets.QMainWindow):
             stack=self.chk_raster_stack.isChecked(),
             stack_range_mm=float(self.stack_range.value()),
             stack_step_mm=float(self.stack_step.value()),
+            af_range_mm=float(self.af_range.value()),
+            af_coarse_step_mm=float(self.af_coarse.value()),
+            af_fine_step_mm=float(self.af_fine.value()),
         )
         # common required points
         x1 = self.rast_x1_spin.value()

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1,9 +1,11 @@
 import gc
+import math
 import os
 import sys
 import time
 from pathlib import Path
 
+import numpy as np
 import pytest
 from PySide6.QtCore import QThread
 
@@ -13,8 +15,44 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 # Stub out the image utilities to avoid heavy Qt GUI imports during tests
 import types
 
+
+def _stub_draw_scale_bar(img, um_per_px):
+    if img is None:
+        return None
+
+    arr = np.array(img, copy=True)
+    if arr.ndim == 2:
+        arr = np.repeat(arr[:, :, None], 3, axis=2)
+
+    h, w = arr.shape[:2]
+    if um_per_px <= 0 or h == 0 or w == 0:
+        return arr
+
+    max_um = 0.2 * w * um_per_px
+    exp = math.floor(math.log10(max_um)) if max_um > 0 else 0
+    nice_um = 10 ** exp
+    for m in (5, 2, 1):
+        candidate = m * (10 ** exp)
+        if candidate <= max_um:
+            nice_um = candidate
+            break
+
+    length_px = int(round(nice_um / um_per_px)) if um_per_px > 0 else 0
+    max_length = max(1, w - 40)
+    length_px = max(1, min(length_px, max_length))
+
+    margin = min(20, w - 1)
+    x0 = max(0, int(round(w - margin - length_px)))
+    y0 = max(0, min(h - 1, int(round(h - margin))))
+    x1 = min(w - 1, x0 + length_px)
+    arr[y0, x0 : x1 + 1] = 255
+    return arr
+
+
 img_stub = types.ModuleType("microstage_app.utils.img")
-img_stub.draw_scale_bar = lambda img, um_per_px: img
+img_stub.draw_scale_bar = _stub_draw_scale_bar
+img_stub.VERT_SCALE = 2
+img_stub.TEXT_SCALE = 4
 sys.modules["microstage_app.utils.img"] = img_stub
 
 from microstage_app.control.raster import RasterRunner, RasterConfig
@@ -62,6 +100,9 @@ def test_raster_config_stack_defaults():
     assert cfg.stack is False
     assert cfg.stack_range_mm == 0.5
     assert cfg.stack_step_mm == 0.01
+    assert cfg.af_range_mm == 0.5
+    assert cfg.af_coarse_step_mm == 0.01
+    assert cfg.af_fine_step_mm == 0.002
 
 
 def test_raster_thread_stop(capsys):


### PR DESCRIPTION
## Summary
- add autofocus range and step settings to `RasterConfig`
- feed the UI autofocus controls into the raster configuration used by the runner
- verify the autofocus parameters are forwarded in tests and provide a light-weight scale bar stub for test isolation

## Testing
- pytest tests/test_raster.py microstage_app/tests/test_raster.py

------
https://chatgpt.com/codex/tasks/task_e_68c88a6323b08324b920e3129fcdeb0f