### PR TITLE
feat: support autofocus configuration in leveling

### DIFF
--- a/microstage_app/control/leveling.py
+++ b/microstage_app/control/leveling.py
@@ -27,6 +27,11 @@ def three_point_level(
     points: Sequence[Tuple[float, float]],
     mode: LevelingMode = LevelingMode.LINEAR,
     stop_event: Event | None = None,
+    *,
+    autofocus_range_mm: float = 0.5,
+    autofocus_coarse_step_mm: float = 0.01,
+    autofocus_fine_step_mm: float = 0.002,
+    autofocus_feed_mm_per_min: float | None = None,
 ) -> SurfaceModel:
     """Fit a focus surface from measurements at multiple XY points.
 
@@ -44,6 +49,15 @@ def three_point_level(
     stop_event : threading.Event, optional
         Event used to signal cancellation. If set, probing stops and a
         ``RuntimeError`` is raised.
+    autofocus_range_mm : float, optional
+        Sweep range in millimetres used for autofocus coarse search.
+    autofocus_coarse_step_mm : float, optional
+        Step size in millimetres for the coarse sweep during autofocus.
+    autofocus_fine_step_mm : float, optional
+        Step size in millimetres for the fine sweep during autofocus.
+    autofocus_feed_mm_per_min : float, optional
+        Feed rate in millimetres per minute used for autofocus moves. When
+        ``None`` the stage default is used.
 
     Returns
     -------
@@ -82,7 +96,16 @@ def three_point_level(
         if AutoFocus and camera is not None:  # pragma: no branch
             try:
                 af = AutoFocus(stage, camera)
-                af.coarse_to_fine(metric=FocusMetric.LAPLACIAN)
+                metric = FocusMetric.LAPLACIAN if FocusMetric is not None else None
+                af_kwargs = {
+                    "metric": metric,
+                    "z_range_mm": autofocus_range_mm,
+                    "coarse_step_mm": autofocus_coarse_step_mm,
+                    "fine_step_mm": autofocus_fine_step_mm,
+                }
+                if autofocus_feed_mm_per_min is not None:
+                    af_kwargs["feed_mm_per_min"] = autofocus_feed_mm_per_min
+                af.coarse_to_fine(**af_kwargs)
                 stage.wait_for_moves()
             except Exception:
                 pass
@@ -130,6 +153,11 @@ def _probe_point(
     y: float,
     autofocus: bool,
     stop_event: Event | None = None,
+    *,
+    autofocus_range_mm: float = 0.5,
+    autofocus_coarse_step_mm: float = 0.01,
+    autofocus_fine_step_mm: float = 0.002,
+    autofocus_feed_mm_per_min: float | None = None,
 ) -> Tuple[float, float, float]:
     """Move to ``(x, y)`` and record the current Z position.
 
@@ -146,6 +174,15 @@ def _probe_point(
     stop_event : threading.Event, optional
         Event used to signal cancellation. When set, a ``RuntimeError``
         is raised.
+    autofocus_range_mm : float, optional
+        Sweep range in millimetres used for autofocus coarse search.
+    autofocus_coarse_step_mm : float, optional
+        Step size in millimetres for the coarse sweep during autofocus.
+    autofocus_fine_step_mm : float, optional
+        Step size in millimetres for the fine sweep during autofocus.
+    autofocus_feed_mm_per_min : float, optional
+        Feed rate in millimetres per minute used for autofocus moves. When
+        ``None`` the stage default is used.
 
     Returns
     -------
@@ -171,7 +208,16 @@ def _probe_point(
         if AutoFocus and camera is not None:  # pragma: no branch
             try:
                 af = AutoFocus(stage, camera)
-                af.coarse_to_fine(metric=FocusMetric.LAPLACIAN)
+                metric = FocusMetric.LAPLACIAN if FocusMetric is not None else None
+                af_kwargs = {
+                    "metric": metric,
+                    "z_range_mm": autofocus_range_mm,
+                    "coarse_step_mm": autofocus_coarse_step_mm,
+                    "fine_step_mm": autofocus_fine_step_mm,
+                }
+                if autofocus_feed_mm_per_min is not None:
+                    af_kwargs["feed_mm_per_min"] = autofocus_feed_mm_per_min
+                af.coarse_to_fine(**af_kwargs)
                 stage.wait_for_moves()
             except Exception:
                 pass
@@ -196,6 +242,11 @@ def grid_level(
     mode: LevelingMode = LevelingMode.LINEAR,
     autofocus: bool = True,
     stop_event: Event | None = None,
+    *,
+    autofocus_range_mm: float = 0.5,
+    autofocus_coarse_step_mm: float = 0.01,
+    autofocus_fine_step_mm: float = 0.002,
+    autofocus_feed_mm_per_min: float | None = None,
 ) -> SurfaceModel:
     """Fit a surface model by probing a grid of points.
 
@@ -219,6 +270,15 @@ def grid_level(
     stop_event : threading.Event, optional
         Event used to signal cancellation. If set, a ``RuntimeError`` is
         raised.
+    autofocus_range_mm : float, optional
+        Sweep range in millimetres used for autofocus coarse search.
+    autofocus_coarse_step_mm : float, optional
+        Step size in millimetres for the coarse sweep during autofocus.
+    autofocus_fine_step_mm : float, optional
+        Step size in millimetres for the fine sweep during autofocus.
+    autofocus_feed_mm_per_min : float, optional
+        Feed rate in millimetres per minute used for autofocus moves. When
+        ``None`` the stage default is used.
 
     Returns
     -------
@@ -236,7 +296,20 @@ def grid_level(
     for x, y in _grid_coords(rect, rows, cols):
         if stop_event and stop_event.is_set():
             raise RuntimeError("operation cancelled")
-        samples.append(_probe_point(stage, camera, x, y, autofocus, stop_event))
+        samples.append(
+            _probe_point(
+                stage,
+                camera,
+                x,
+                y,
+                autofocus,
+                stop_event,
+                autofocus_range_mm=autofocus_range_mm,
+                autofocus_coarse_step_mm=autofocus_coarse_step_mm,
+                autofocus_fine_step_mm=autofocus_fine_step_mm,
+                autofocus_feed_mm_per_min=autofocus_feed_mm_per_min,
+            )
+        )
 
     model = SurfaceModel(kind=SurfaceKind(mode.value))
     model.fit(samples)

--- a/microstage_app/tests/test_leveling.py
+++ b/microstage_app/tests/test_leveling.py
@@ -83,12 +83,13 @@ def test_three_point_level_autofocus_called(monkeypatch):
 
     class DummyAF:
         calls = 0
+        kwargs = []
 
         def __init__(self, stage, camera):
             DummyAF.calls += 1
 
-        def coarse_to_fine(self, metric=None):
-            pass
+        def coarse_to_fine(self, metric=None, **kwargs):
+            DummyAF.kwargs.append({"metric": metric, **kwargs})
 
     monkeypatch.setattr(leveling, "AutoFocus", DummyAF)
 
@@ -98,8 +99,31 @@ def test_three_point_level_autofocus_called(monkeypatch):
     stage = DummyStage(plane)
     cam = DummyCamera()
     pts = [(0, 0), (1, 0), (0, 1)]
-    model = three_point_level(stage, cam, pts, LevelingMode.LINEAR)
+    expected_metric = (
+        getattr(leveling.FocusMetric, "LAPLACIAN", None)
+        if getattr(leveling, "FocusMetric", None) is not None
+        else None
+    )
+    model = three_point_level(
+        stage,
+        cam,
+        pts,
+        LevelingMode.LINEAR,
+        autofocus_range_mm=0.75,
+        autofocus_coarse_step_mm=0.02,
+        autofocus_fine_step_mm=0.003,
+        autofocus_feed_mm_per_min=123.0,
+    )
     assert DummyAF.calls == len(pts)
+    assert len(DummyAF.kwargs) == len(pts)
+    for kwargs in DummyAF.kwargs:
+        assert kwargs == {
+            "metric": expected_metric,
+            "z_range_mm": 0.75,
+            "coarse_step_mm": 0.02,
+            "fine_step_mm": 0.003,
+            "feed_mm_per_min": 123.0,
+        }
     assert np.isclose(model.predict(2, 3), plane(2, 3))
 
 
@@ -126,12 +150,13 @@ def test_grid_level_linear_autofocus(monkeypatch):
 
     class DummyAF:
         calls = 0
+        kwargs = []
 
         def __init__(self, stage, camera):
             DummyAF.calls += 1
 
-        def coarse_to_fine(self, metric=None):
-            pass
+        def coarse_to_fine(self, metric=None, **kwargs):
+            DummyAF.kwargs.append({"metric": metric, **kwargs})
 
     monkeypatch.setattr(leveling, "AutoFocus", DummyAF)
 
@@ -141,8 +166,33 @@ def test_grid_level_linear_autofocus(monkeypatch):
     stage = DummyStage(plane)
     cam = DummyCamera()
     rect = (0.0, 0.0, 1.0, 1.0)
-    model = grid_level(stage, cam, rect, rows=2, cols=2, mode=LevelingMode.LINEAR)
+    expected_metric = (
+        getattr(leveling.FocusMetric, "LAPLACIAN", None)
+        if getattr(leveling, "FocusMetric", None) is not None
+        else None
+    )
+    model = grid_level(
+        stage,
+        cam,
+        rect,
+        rows=2,
+        cols=2,
+        mode=LevelingMode.LINEAR,
+        autofocus_range_mm=0.9,
+        autofocus_coarse_step_mm=0.05,
+        autofocus_fine_step_mm=0.004,
+        autofocus_feed_mm_per_min=321.0,
+    )
     assert DummyAF.calls == 4
+    assert len(DummyAF.kwargs) == 4
+    for kwargs in DummyAF.kwargs:
+        assert kwargs == {
+            "metric": expected_metric,
+            "z_range_mm": 0.9,
+            "coarse_step_mm": 0.05,
+            "fine_step_mm": 0.004,
+            "feed_mm_per_min": 321.0,
+        }
     assert np.isclose(model.predict(2, 3), plane(2, 3))
 
 
@@ -155,7 +205,7 @@ def test_grid_level_manual_records_z(monkeypatch):
         def __init__(self, stage, camera):
             DummyAF.calls += 1
 
-        def coarse_to_fine(self, metric=None):
+        def coarse_to_fine(self, metric=None, **kwargs):
             pass
 
     monkeypatch.setattr(leveling, "AutoFocus", DummyAF)


### PR DESCRIPTION
## Summary
- allow three_point_level, grid_level, and the internal probe helper to accept autofocus range, step, and feed configuration
- pass the autofocus parameters through to AutoFocus when available while tolerating environments without FocusMetric
- extend leveling tests to verify autofocus settings are forwarded to AutoFocus stubs

## Testing
- pytest microstage_app/tests/test_leveling.py
- pytest tests/test_leveling_manual_controls.py (fails: libGL.so.1 missing in environment)


------
https://chatgpt.com/codex/tasks/task_e_68c88d1721d483248f93a3d683f1db13