### PR TITLE
Use stage bounds for leveling workspace

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2318,6 +2318,56 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_level_continue.setVisible(False)
         self._level_continue_event.set()
 
+    def _stage_workspace_polygon(self):
+        """Return a polygon covering the full XY travel of the stage."""
+
+        bounds = {}
+
+        stage_bounds = getattr(self, "stage_bounds", None)
+        if stage_bounds:
+            for key in ("xmin", "xmax", "ymin", "ymax"):
+                val = stage_bounds.get(key)
+                if val is not None:
+                    bounds[key] = float(val)
+
+        fallback = getattr(self, "_stage_bounds_fallback", None)
+        if fallback:
+            for key in ("xmin", "xmax", "ymin", "ymax"):
+                if key in bounds:
+                    continue
+                val = fallback.get(key)
+                if val is not None:
+                    bounds[key] = float(val)
+
+        stage = getattr(self, "stage", None)
+        if stage is not None:
+            try:
+                live = stage.get_bounds()
+            except Exception as exc:
+                log(f"Stage: failed to query bounds for workspace polygon: {exc}")
+            else:
+                if live:
+                    for key in ("xmin", "xmax", "ymin", "ymax"):
+                        val = live.get(key)
+                        if val is not None:
+                            bounds[key] = float(val)
+
+        required = ("xmin", "xmax", "ymin", "ymax")
+        if any(key not in bounds for key in required):
+            return None
+
+        xmin = bounds["xmin"]
+        xmax = bounds["xmax"]
+        ymin = bounds["ymin"]
+        ymax = bounds["ymax"]
+
+        return [
+            (xmin, ymin),
+            (xmax, ymin),
+            (xmax, ymax),
+            (xmin, ymax),
+        ]
+
     def _set_level_point(self, idx: int):
         if not self.stage_worker:
             log("Leveling point ignored: stage not connected")
@@ -2466,9 +2516,20 @@ class MainWindow(QtWidgets.QMainWindow):
                     pts.append((x_meas, y_meas, z))
             model = SurfaceModel(kind)
             model.fit(pts)
+            polygon = self._stage_workspace_polygon()
+            if polygon is None:
+                log(
+                    "Leveling: stage bounds unavailable; using probed area bounding box"
+                )
+                polygon = [
+                    (xmin, ymin),
+                    (xmax, ymin),
+                    (xmax, ymax),
+                    (xmin, ymax),
+                ]
             area = Area(
                 "bed",
-                [(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)],
+                polygon,
                 model,
             )
             self.focus_mgr.areas.clear()


### PR DESCRIPTION
## Summary
- add a helper to compute the full stage workspace polygon from reported limits or configuration fallback
- store leveling results with a full-travel polygon so z-offset corrections apply across the entire stage when multi-area leveling is disabled

## Testing
- pytest microstage_app/tests/test_leveling.py

------
https://chatgpt.com/codex/tasks/task_e_68c88f90708483249206e47122f7f985