### PR TITLE
Tighten right panel layout

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -783,10 +783,16 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Right: tabs
         rightw = QtWidgets.QTabWidget()
+        rightw.setMaximumWidth(350)  # tweak as needed
+        rightw.setSizePolicy(
+            QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Preferred
+        )
 
         # ---- Camera tab (performance controls)
         camtab = QtWidgets.QWidget()
         c = QtWidgets.QGridLayout(camtab)
+        c.setColumnStretch(1, 1)
+        c.setColumnStretch(2, 0)
         row = 0
         self.exp_spin = QtWidgets.QDoubleSpinBox(); self.exp_spin.setRange(0.01, 10000.0); self.exp_spin.setValue(10.0)
         self.exp_spin.setSuffix(" ms")
@@ -853,6 +859,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # Leveling controls
         lvl_box = QtWidgets.QGroupBox("Leveling")
         l = QtWidgets.QGridLayout(lvl_box)
+        l.setColumnStretch(1, 1)
+        l.setColumnStretch(3, 1)
+        l.setColumnStretch(4, 0)
         self.level_method = QtWidgets.QComboBox(); self.level_method.addItems(["Three-point", "Grid"])
         self.level_poly = QtWidgets.QComboBox(); self.level_poly.addItems(["Linear", "Quadratic", "Cubic"])
         self.level_rows = QtWidgets.QSpinBox(); self.level_rows.setRange(2, 10); self.level_rows.setValue(3)
@@ -898,6 +907,10 @@ class MainWindow(QtWidgets.QMainWindow):
         # Raster controls
         rast_box = QtWidgets.QGroupBox("Raster")
         r = QtWidgets.QGridLayout(rast_box)
+        r.setColumnStretch(1, 1)
+        r.setColumnStretch(3, 1)
+        r.setColumnStretch(4, 0)
+        r.setColumnStretch(5, 0)
         self.rows_spin = QtWidgets.QSpinBox(); self.rows_spin.setRange(1, 1000); self.rows_spin.setValue(5)
         self.cols_spin = QtWidgets.QSpinBox(); self.cols_spin.setRange(1, 1000); self.cols_spin.setValue(5)
 


### PR DESCRIPTION
## Summary
- cap the right-hand tab widget width and use a maximum horizontal size policy so the control stack stays narrow
- tune the camera, leveling, and raster grid layouts to stretch slider columns while keeping spin boxes compact

## Testing
- QT_QPA_PLATFORM=offscreen python - <<'PY'
from PySide6 import QtWidgets
from microstage_app.ui.main_window import MainWindow

app = QtWidgets.QApplication([])
win = MainWindow()
rightw = win.findChild(QtWidgets.QTabWidget)
print("rightw maximum width:", rightw.maximumWidth())
policy = rightw.sizePolicy()
print("rightw size policy:", policy.horizontalPolicy(), policy.verticalPolicy())
camtab = rightw.widget(0)
cam_layout = camtab.layout()
print("camera layout column stretches:", cam_layout.columnStretch(1), cam_layout.columnStretch(2))
area_tab = rightw.widget(1)
area_layout = area_tab.layout()
for i in range(area_layout.count()):
    item = area_layout.itemAt(i)
    w = item.widget()
    if isinstance(w, QtWidgets.QGroupBox):
        layout = w.layout()
        print(f"{w.title()} layout stretches:", [layout.columnStretch(j) for j in range(layout.columnCount())])
win.close()
app.quit()
PY

------
https://chatgpt.com/codex/tasks/task_e_68c92c155d04832488693cc1055b2080