### PR TITLE
Update stage position after autofocus completes

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -2289,6 +2289,10 @@ class MainWindow(QtWidgets.QMainWindow):
             QtWidgets.QMessageBox.information(
                 self, "Autofocus", f"Best Z offset (relative): {best:.6f} mm"
             )
+            if self.stage_worker:
+                self.stage_worker.enqueue(
+                    self.stage.get_position, callback=self._on_stage_position
+                )
 
     @QtCore.Slot()
     def _cleanup_autofocus_thread(self):


### PR DESCRIPTION
## Summary
- refresh the stage position display after autofocus completes by enqueuing a get_position call

## Testing
- pytest *(fails: missing libGL.so.1 in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95101100c83249c53d7bfa55d2ae4