### PR TITLE
Add capture timestamp prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ will be enabled.
 The capture panel lets you choose an output folder and base filename. The fields
 are validated: the directory must be writable (it will be created if missing) and
 the name cannot contain characters such as `\\ / : * ? \" < > |`. The directory,
-base name, and auto-number option are all remembered between runs. Captures
+base name, auto-prefix, and auto-number options are all remembered between runs. Captures
 default to PNG to retain embedded metadata, with BMP, TIFF and JPEG also
 available.
 
 Enabling **Auto-number (_n)** appends an incrementing suffix when a file with the
 same name already exists, preventing accidental overwrites.
+
+Enable **Auto-prefix (yyyymmddhhmmss_)** to prepend a timestamp such as
+`20240101123045_` to each capture. When both toggles are active the timestamp
+comes first, followed by the auto-number suffix (e.g. `20240101123045_sample_1.tif`).
 
 Example usage:
 
@@ -97,7 +101,8 @@ Saved fields include:
 - **Camera**: exposure time (`exposure_ms`), gain (1.0–4.0x), and binning.
 - **Scan presets**: default area region (`x1_mm`, `y1_mm`, `x2_mm`,
   `y2_mm`, `rows`, `cols`).
-- **Capture**: last used directory, base filename, auto-number toggle, and
+- **Capture**: last used directory, base filename, auto-prefix toggle,
+  auto-number toggle, and
   file format.
 - **Jog panel**: step sizes, feed rates, and absolute positions for each axis.
 

--- a/microstage_app/control/profiles.py
+++ b/microstage_app/control/profiles.py
@@ -2,7 +2,7 @@ import yaml, os, copy
 from ..utils.log import log
 
 DEFAULTS = {
-    'version': 5,
+    'version': 6,
     'stage': {'feed_mm_s': 50.0 / 60.0, 'settle_ms': 30},
     'camera': {
         'exposure_ms': 10.0,
@@ -43,7 +43,13 @@ DEFAULTS = {
         }
     },
     # persistent capture settings
-    'capture': {'dir': '', 'name': 'capture', 'auto_number': False, 'format': 'png'},
+    'capture': {
+        'dir': '',
+        'name': 'capture',
+        'auto_prefix': False,
+        'auto_number': False,
+        'format': 'png',
+    },
     # jog UI persistence
     'jog': {
         'step': {'x': 0.1, 'y': 0.1, 'z': 0.1},

--- a/microstage_app/control/raster.py
+++ b/microstage_app/control/raster.py
@@ -61,6 +61,7 @@ class RasterRunner:
         cfg: RasterConfig,
         directory=None,
         base_name="tile",
+        auto_prefix=False,
         auto_number=False,
         fmt="tif",
         position_cb=None,
@@ -74,6 +75,7 @@ class RasterRunner:
         self.cfg = cfg
         self.directory = directory
         self.base_name = base_name
+        self.auto_prefix = auto_prefix
         self.auto_number = auto_number
         self.fmt = fmt
         self.position_cb = position_cb
@@ -236,6 +238,7 @@ class RasterRunner:
                             img,
                             directory=self.directory,
                             filename=fname,
+                            auto_prefix=self.auto_prefix,
                             auto_number=self.auto_number,
                             fmt=self.fmt,
                             metadata=metadata,

--- a/microstage_app/io/storage.py
+++ b/microstage_app/io/storage.py
@@ -19,6 +19,7 @@ class ImageWriter:
         img_rgb,
         directory=None,
         filename="capture",
+        auto_prefix=False,
         auto_number=False,
         fmt="bmp",
         metadata=None,
@@ -33,6 +34,9 @@ class ImageWriter:
             Destination directory. Defaults to ``self.run_dir``.
         filename : str
             Base filename without extension.
+        auto_prefix : bool
+            If ``True``, prepend a ``YYYYMMDDHHMMSS_`` timestamp to ``filename``
+            before saving.
         auto_number : bool
             If ``True``, append ``_n`` to ``filename`` where ``n`` increments
             to avoid overwriting existing files.
@@ -55,15 +59,19 @@ class ImageWriter:
             "jpeg": "jpg",
         }.get(fmt, "bmp")
 
+        base_name = filename
+        if auto_prefix:
+            base_name = f"{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}_{base_name}"
+
         if auto_number:
             n = 1
             while True:
-                path = os.path.join(directory, f"{filename}_{n}.{ext}")
+                path = os.path.join(directory, f"{base_name}_{n}.{ext}")
                 if not os.path.exists(path):
                     break
                 n += 1
         else:
-            path = os.path.join(directory, f"{filename}.{ext}")
+            path = os.path.join(directory, f"{base_name}.{ext}")
 
         if ext == "tif":
             self._save_tiff(path, img_rgb, metadata)

--- a/microstage_app/tests/test_capture_settings_persist.py
+++ b/microstage_app/tests/test_capture_settings_persist.py
@@ -34,6 +34,7 @@ def test_capture_settings_persist(monkeypatch, tmp_path, qt_app):
     win1.capture_dir_edit.setText(dir1)
     win1.capture_name_edit.setText("foo")
     win1.autonumber_chk.setChecked(True)
+    win1.autoprefix_chk.setChecked(True)
     assert win1.capture_format == "png"
     assert win1.format_combo.currentText() == "PNG"
     win1.format_combo.setCurrentText("BMP")
@@ -48,6 +49,8 @@ def test_capture_settings_persist(monkeypatch, tmp_path, qt_app):
     assert win2.capture_name_edit.text() == "foo"
     assert win2.auto_number is True
     assert win2.autonumber_chk.isChecked()
+    assert win2.auto_prefix is True
+    assert win2.autoprefix_chk.isChecked()
     assert win2.capture_format == "bmp"
     assert win2.format_combo.currentText() == "BMP"
     win2.preview_timer.stop(); win2.fps_timer.stop(); win2.close()

--- a/microstage_app/tests/test_image_writer.py
+++ b/microstage_app/tests/test_image_writer.py
@@ -1,8 +1,12 @@
+import datetime
+import json
+
 import numpy as np
-from microstage_app.io.storage import ImageWriter
 import tifffile
 from PIL import Image
-import json
+
+import microstage_app.io.storage as storage
+from microstage_app.io.storage import ImageWriter
 
 
 def test_save_single_custom_dir_and_name(tmp_path):
@@ -22,6 +26,56 @@ def test_save_single_autonumber(tmp_path):
     assert not (out_dir / "foo.bmp").exists()
     assert (out_dir / "foo_1.bmp").exists()
     assert (out_dir / "foo_2.bmp").exists()
+
+
+def test_save_single_auto_prefix(monkeypatch, tmp_path):
+    writer = ImageWriter(base_dir=str(tmp_path / "runs"))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    out_dir = tmp_path / "prefix"
+    timestamp = datetime.datetime(2024, 2, 3, 4, 5, 6)
+
+    class FixedDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return timestamp
+
+    monkeypatch.setattr(storage.datetime, "datetime", FixedDateTime)
+
+    writer.save_single(img, directory=str(out_dir), filename="foo", auto_prefix=True)
+    expected = out_dir / "20240203040506_foo.bmp"
+    assert expected.exists()
+
+
+def test_save_single_auto_prefix_with_autonumber(monkeypatch, tmp_path):
+    writer = ImageWriter(base_dir=str(tmp_path / "runs"))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    out_dir = tmp_path / "prefix_auto"
+    timestamp = datetime.datetime(2024, 5, 6, 7, 8, 9)
+
+    class FixedDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return timestamp
+
+    monkeypatch.setattr(storage.datetime, "datetime", FixedDateTime)
+
+    writer.save_single(
+        img,
+        directory=str(out_dir),
+        filename="foo",
+        auto_prefix=True,
+        auto_number=True,
+    )
+    writer.save_single(
+        img,
+        directory=str(out_dir),
+        filename="foo",
+        auto_prefix=True,
+        auto_number=True,
+    )
+    assert not (out_dir / "20240506070809_foo.bmp").exists()
+    assert (out_dir / "20240506070809_foo_1.bmp").exists()
+    assert (out_dir / "20240506070809_foo_2.bmp").exists()
 
 
 def test_save_png(tmp_path):

--- a/microstage_app/tests/test_profiles_migration.py
+++ b/microstage_app/tests/test_profiles_migration.py
@@ -11,10 +11,12 @@ def test_profiles_migration(monkeypatch, tmp_path):
     assert p.data['version'] == Profiles.VERSION
     assert p.data['camera']['gain'] == 2.0
     assert p.data['camera']['exposure_ms'] == DEFAULTS['camera']['exposure_ms']
+    assert p.data['capture']['auto_prefix'] is False
     assert p.data['measurement']['lenses']['10x']['um_per_px'] == 1.23
     assert p.data['measurement']['lenses']['10x']['calibrations'] == {}
     saved = yaml.safe_load(pfile.read_text())
     assert saved['version'] == Profiles.VERSION
     assert 'capture' in saved
+    assert saved['capture']['auto_prefix'] is False
     assert saved['measurement']['lenses']['10x']['um_per_px'] == 1.23
     assert saved['measurement']['lenses']['10x']['calibrations'] == {}

--- a/microstage_app/tests/test_raster.py
+++ b/microstage_app/tests/test_raster.py
@@ -49,11 +49,22 @@ class WriterMock:
         img,
         directory=None,
         filename="capture",
+        auto_prefix=False,
         auto_number=False,
         fmt="bmp",
         metadata=None,
     ):
-        self.saved.append((img, directory, filename, auto_number, fmt, metadata))
+        self.saved.append(
+            {
+                "img": img,
+                "directory": directory,
+                "filename": filename,
+                "auto_prefix": auto_prefix,
+                "auto_number": auto_number,
+                "fmt": fmt,
+                "metadata": metadata,
+            }
+        )
 
 
 @pytest.mark.parametrize("mode", ["rectangle", "parallelogram", "trapezoid"])
@@ -102,9 +113,9 @@ def test_raster_traversal_modes(mode, serpentine):
             expected_meta.append((r, c))
 
     assert stage.moves == expected_moves
-    assert [f[2] for f in writer.saved] == expected_files
-    assert [m[5]["Row"] for m in writer.saved] == [r for r, _ in expected_meta]
-    assert [m[5]["Column"] for m in writer.saved] == [c for _, c in expected_meta]
+    assert [entry["filename"] for entry in writer.saved] == expected_files
+    assert [entry["metadata"]["Row"] for entry in writer.saved] == [r for r, _ in expected_meta]
+    assert [entry["metadata"]["Column"] for entry in writer.saved] == [c for _, c in expected_meta]
 
 
 def test_raster_capture_disabled():

--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -454,6 +454,7 @@ class MainWindow(QtWidgets.QMainWindow):
                                         expected_type=str)
         self.capture_dir = dir_profile if dir_profile else self.image_writer.run_dir
         self.capture_name = self.profiles.get('capture.name', "capture", expected_type=str)
+        self.auto_prefix = self.profiles.get('capture.auto_prefix', False, expected_type=bool)
         self.auto_number = self.profiles.get('capture.auto_number', False, expected_type=bool)
         fmt = self.profiles.get('capture.format', 'png', expected_type=str)
         if fmt.lower() not in {"bmp", "tif", "png", "jpg"}:
@@ -772,6 +773,14 @@ class MainWindow(QtWidgets.QMainWindow):
             "the same name exists to avoid overwriting. Setting persists."
         )
         ctr4.addWidget(self.autonumber_chk)
+        self.autoprefix_chk = QtWidgets.QCheckBox("Auto-prefix (yyyymmddhhmmss_)")
+        self.autoprefix_chk.setChecked(self.auto_prefix)
+        self.autoprefix_chk.setToolTip(
+            "When enabled, prepend a timestamp such as 20240101010101_ to the "
+            "base filename for every capture. Auto-numbering still applies "
+            "after the prefix when enabled."
+        )
+        ctr4.addWidget(self.autoprefix_chk)
         ctr4.addWidget(QtWidgets.QLabel("Format:"))
         self.format_combo = QtWidgets.QComboBox()
         self.format_combo.addItems(["BMP", "TIF", "PNG", "JPG"])
@@ -1133,6 +1142,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.capture_dir_edit.textChanged.connect(self._on_capture_dir_changed)
         self.capture_name_edit.textChanged.connect(self._on_capture_name_changed)
         self.autonumber_chk.toggled.connect(self._on_autonumber_toggled)
+        self.autoprefix_chk.toggled.connect(self._on_autoprefix_toggled)
         self.format_combo.currentTextChanged.connect(self._on_format_changed)
         self.btn_browse_dir.clicked.connect(self._browse_capture_dir)
 
@@ -1203,6 +1213,11 @@ class MainWindow(QtWidgets.QMainWindow):
     def _on_autonumber_toggled(self, checked: bool):
         self.auto_number = checked
         self.profiles.set('capture.auto_number', checked)
+        self.profiles.save()
+
+    def _on_autoprefix_toggled(self, checked: bool):
+        self.auto_prefix = checked
+        self.profiles.set('capture.auto_prefix', checked)
         self.profiles.save()
 
     def _on_format_changed(self, text: str):
@@ -1899,6 +1914,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.btn_browse_dir,
             self.capture_name_edit,
             self.autonumber_chk,
+            self.autoprefix_chk,
             self.format_combo,
             self.depth_combo,
             self.raw_chk,
@@ -2181,6 +2197,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         directory = self.capture_dir
         name = self.capture_name
+        auto_prefix = self.auto_prefix
         auto_num = self.auto_number
 
         # validate directory
@@ -2265,6 +2282,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     img,
                     directory=directory,
                     filename=name,
+                    auto_prefix=auto_prefix,
                     auto_number=auto_num,
                     fmt=self.capture_format,
                     metadata=meta,
@@ -2822,6 +2840,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         directory = self.capture_dir
         name = self.capture_name
+        auto_prefix = self.auto_prefix
         auto_num = self.auto_number
         fmt = self.capture_format
 
@@ -2854,6 +2873,7 @@ class MainWindow(QtWidgets.QMainWindow):
             cfg,
             directory=directory,
             base_name=name,
+            auto_prefix=auto_prefix,
             auto_number=auto_num,
             fmt=fmt,
             position_cb=lambda pos: self.stage_worker.enqueue(

--- a/tests/test_image_writer.py
+++ b/tests/test_image_writer.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import sys
 import json
+import datetime
 
 import numpy as np
 import pytest
@@ -9,6 +10,8 @@ from PIL import Image
 
 # Ensure the repository root is on sys.path so ``microstage_app`` is importable
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import microstage_app.io.storage as storage
 from microstage_app.io.storage import ImageWriter
 
 
@@ -43,6 +46,55 @@ def test_filename_generation_with_auto_numbering(tmp_path):
     assert not (out_dir / "foo.bmp").exists()
     assert (out_dir / "foo_1.bmp").exists()
     assert (out_dir / "foo_2.bmp").exists()
+
+
+def test_auto_prefix(monkeypatch, tmp_path):
+    writer = ImageWriter(base_dir=str(tmp_path / "runs"))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    out_dir = tmp_path / "prefix"
+    timestamp = datetime.datetime(2024, 7, 8, 9, 10, 11)
+
+    class FixedDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return timestamp
+
+    monkeypatch.setattr(storage.datetime, "datetime", FixedDateTime)
+
+    writer.save_single(img, directory=str(out_dir), filename="foo", auto_prefix=True)
+    assert (out_dir / "20240708091011_foo.bmp").exists()
+
+
+def test_auto_prefix_with_autonumber(monkeypatch, tmp_path):
+    writer = ImageWriter(base_dir=str(tmp_path / "runs"))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    out_dir = tmp_path / "prefix_auto"
+    timestamp = datetime.datetime(2024, 7, 8, 9, 10, 11)
+
+    class FixedDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return timestamp
+
+    monkeypatch.setattr(storage.datetime, "datetime", FixedDateTime)
+
+    writer.save_single(
+        img,
+        directory=str(out_dir),
+        filename="foo",
+        auto_prefix=True,
+        auto_number=True,
+    )
+    writer.save_single(
+        img,
+        directory=str(out_dir),
+        filename="foo",
+        auto_prefix=True,
+        auto_number=True,
+    )
+    assert not (out_dir / "20240708091011_foo.bmp").exists()
+    assert (out_dir / "20240708091011_foo_1.bmp").exists()
+    assert (out_dir / "20240708091011_foo_2.bmp").exists()
 
 
 def test_creates_missing_directory(tmp_path):


### PR DESCRIPTION
## Summary
- add an auto-prefix capture setting with profile migration and a UI toggle next to the existing auto-number option
- plumb the timestamp prefix through ImageWriter and RasterRunner so single captures and rasters use the new flag
- document the feature and extend tests to cover timestamp prefixes and persistence

## Testing
- pytest microstage_app/tests *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- pytest tests *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d3b4bb348324a7cff52a1e3cbc59