### PR TITLE
Move device status labels into system monitor tab

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -584,9 +584,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.profile_combo = QtWidgets.QComboBox()
         self.btn_reload_profiles = QtWidgets.QPushButton("Reload Profiles")
         self.profile_label = QtWidgets.QLabel("Profile:")
-        left.addWidget(self.stage_status)
-        left.addWidget(self.cam_status)
-        left.addSpacing(8)
         left.addWidget(self.profile_label)
         left.addWidget(self.profile_combo)
         left.addWidget(self.btn_reload_profiles)
@@ -1007,6 +1004,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # ---- System monitor tab
         self.system_tab = SystemMonitorTab()
+        self.system_tab.add_device_status_widgets(self.stage_status, self.cam_status)
         rightw.addTab(self.system_tab, "System")
         self.system_tab.start()
 

--- a/microstage_app/ui/system_monitor_tab.py
+++ b/microstage_app/ui/system_monitor_tab.py
@@ -34,7 +34,10 @@ class SystemMonitorTab(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
 
-        layout = QtWidgets.QVBoxLayout(self)
+        self._layout = QtWidgets.QVBoxLayout(self)
+        layout = self._layout
+
+        self._status_layout: QtWidgets.QVBoxLayout | None = None
 
         # CPU widgets
         self.proc = psutil.Process()
@@ -73,6 +76,24 @@ class SystemMonitorTab(QtWidgets.QWidget):
 
         # ensure right-click tooltips for any interactive widgets
         apply_tooltip_context(self)
+
+    # ------------------------------------------------------------------
+    def add_device_status_widgets(self, *widgets: QtWidgets.QWidget | None) -> None:
+        """Place external device status widgets above the utilization meters."""
+
+        valid_widgets = [w for w in widgets if w is not None]
+        if not valid_widgets:
+            return
+
+        if self._status_layout is None:
+            self._status_layout = QtWidgets.QVBoxLayout()
+            self._status_layout.setContentsMargins(0, 0, 0, 0)
+            self._status_layout.setSpacing(2)
+            self._layout.insertLayout(0, self._status_layout)
+            self._layout.insertSpacing(1, 8)
+
+        for widget in valid_widgets:
+            self._status_layout.addWidget(widget)
 
     # ------------------------------------------------------------------
     def start(self) -> None:


### PR DESCRIPTION
## Summary
- allow the system monitor tab to receive external device status widgets so they appear above the utilization meters
- pass the stage and camera status labels into the system monitor tab and remove them from the left column layout

## Testing
- python -m compileall microstage_app/ui/system_monitor_tab.py microstage_app/ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d9ea70848324ab75d3e1ab34f8d4