### PR TITLE
Align scale bar font sizing between Qt and Pillow

### DIFF
--- a/microstage_app/tests/test_scale_bar.py
+++ b/microstage_app/tests/test_scale_bar.py
@@ -1,7 +1,8 @@
 import os
 from types import SimpleNamespace
 import math
-from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import numpy as np
 import pytest
@@ -116,6 +117,9 @@ def test_preview_scale_bar_pen_and_font(monkeypatch, qt_app):
 
     def fake_setFont(self, font):
         captured["font_size"] = font.pointSizeF()
+        captured["font_pixel_size"] = font.pixelSize()
+        captured["font"] = QtGui.QFont(font)
+        captured["metrics_height"] = QtGui.QFontMetricsF(font).height()
         orig_setFont(self, font)
 
     monkeypatch.setattr(QtGui.QPainter, "setPen", fake_setPen)
@@ -127,8 +131,34 @@ def test_preview_scale_bar_pen_and_font(monkeypatch, qt_app):
     painter.end()
 
     assert captured["pen_width"] == 2 * VERT_SCALE
-    base_size = QtGui.QFont().pointSizeF()
-    assert captured["font_size"] == pytest.approx(base_size * TEXT_SCALE)
+    app_font = QtGui.QFont(qt_app.font())
+    base_point = app_font.pointSizeF()
+    if base_point > 0:
+        assert captured["font_size"] == pytest.approx(base_point * TEXT_SCALE)
+    else:
+        expected_pixel = app_font.pixelSize() * TEXT_SCALE
+        assert captured["font_pixel_size"] == expected_pixel
+
+    assert "metrics_height" in captured
+
+    from microstage_app.utils import img as img_utils
+
+    img_utils._scale_font_cache = None
+    height_capture = {}
+    original_textbbox = ImageDraw.ImageDraw.textbbox
+
+    def spy_textbbox(self, xy, text, font=None, *args, **kwargs):
+        bbox = original_textbbox(self, xy, text, font=font, *args, **kwargs)
+        height_capture["height"] = bbox[3] - bbox[1]
+        return bbox
+
+    monkeypatch.setattr(ImageDraw.ImageDraw, "textbbox", spy_textbbox)
+    draw_scale_bar(np.zeros((100, 200, 3), dtype=np.uint8), 1.0)
+
+    assert "height" in height_capture
+    assert height_capture["height"] == pytest.approx(
+        captured["metrics_height"], abs=2.0
+    )
     view.close()
 
 
@@ -146,7 +176,7 @@ def test_scale_bar_mu_character_renders(monkeypatch, tmp_path, qt_app):
     from microstage_app.utils import img as img_utils
     img_utils._scale_font_cache = None
 
-    out = draw_scale_bar(img, 0.2)
+    out = draw_scale_bar(img, 0.05)
     Image.fromarray(out).save(tmp_path / "scale.png")
 
     font_path = used["path"]
@@ -156,7 +186,7 @@ def test_scale_bar_mu_character_renders(monkeypatch, tmp_path, qt_app):
     monkeypatch.setattr(ImageFont, "truetype", orig_truetype)
 
     h, w, _ = img.shape
-    um_per_px = 0.2
+    um_per_px = 0.05
     max_um = 0.2 * w * um_per_px
     exp = math.floor(math.log10(max_um)) if max_um > 0 else 0
     nice_um = 10 ** exp
@@ -169,14 +199,7 @@ def test_scale_bar_mu_character_renders(monkeypatch, tmp_path, qt_app):
     x0 = int(round(w - 20 - length_px))
     y0 = int(round(h - 20))
 
-    qfont = qt_app.font()
-    ps = qfont.pointSizeF()
-    if ps > 0:
-        base_size = ps
-    else:
-        base_size = qfont.pixelSize()
-    font_size = int(round(base_size * TEXT_SCALE))
-    font = ImageFont.truetype(str(Path(font_path).resolve()), font_size)
+    font = img_utils._load_scale_font()
     dummy = Image.new("RGB", (1, 1))
     draw = ImageDraw.Draw(dummy)
     label = f"{nice_um:.0f} µm"
@@ -185,10 +208,12 @@ def test_scale_bar_mu_character_renders(monkeypatch, tmp_path, qt_app):
     mu_w = draw.textlength("µ", font=font)
     th = bbox[3] - bbox[1]
     y_text = y0 - (7 * TEXT_SCALE) - th
+    y_start = max(0, y_text)
+    y_end = min(h, y_text + th)
 
-    x_start = int(x0 + pre)
-    x_end = int(min(w, x0 + pre + mu_w))
-    mu_region = out[y_text : y_text + th, x_start:x_end]
+    x_start = int(max(0, math.floor(x0 + pre)))
+    x_end = int(min(w, math.ceil(x0 + pre + mu_w)))
+    mu_region = out[y_start:y_end, x_start:x_end]
     assert mu_region.size > 0 and np.any(mu_region == 255)
 
 

--- a/microstage_app/utils/img.py
+++ b/microstage_app/utils/img.py
@@ -41,7 +41,7 @@ def _show_font_error_dialog(message: str) -> None:
         _font_error_reported = True
 
 
-def _load_default_scale_font(reason: str, font_size: int) -> ImageFont.ImageFont:
+def _load_default_scale_font(reason: str, pixel_size: int) -> ImageFont.ImageFont:
     """Load a bundled or Pillow default font and log the fallback reason."""
 
     fallback_candidates = (
@@ -51,7 +51,7 @@ def _load_default_scale_font(reason: str, font_size: int) -> ImageFont.ImageFont
 
     for candidate in fallback_candidates:
         try:
-            font = ImageFont.truetype(str(candidate), font_size)
+            font = ImageFont.truetype(str(candidate), pixel_size)
         except OSError:
             continue
 
@@ -104,16 +104,26 @@ def _load_scale_font() -> ImageFont.ImageFont:
     if qapp is None:
         raise RuntimeError("QGuiApplication instance required to load font")
 
-    qfont = qapp.font()
-    ps = qfont.pointSizeF()
-    if ps > 0:
-        base_size = ps
+    qfont = QtGui.QFont(qapp.font())
+    original_point_size = qfont.pointSizeF()
+    if original_point_size > 0:
+        qfont.setPointSizeF(original_point_size * TEXT_SCALE)
     else:
-        base_size = qfont.pixelSize()
+        qfont.setPixelSize(qfont.pixelSize() * TEXT_SCALE)
 
-    font_size = int(round(base_size * TEXT_SCALE))
+    metrics = QtGui.QFontMetricsF(qfont)
+    pixel_size = int(round(metrics.height()))
+    if pixel_size <= 0:
+        info = QtGui.QFontInfo(qfont)
+        pixel_size = info.pixelSize()
+    if pixel_size <= 0:
+        fallback = qfont.pixelSize()
+        if fallback <= 0 and original_point_size > 0:
+            fallback = int(round(original_point_size * TEXT_SCALE))
+        pixel_size = fallback
+    pixel_size = max(1, int(round(pixel_size)))
 
-    family = qfont.family()
+    family = QtGui.QFontInfo(qfont).family() or qfont.family()
     font: ImageFont.ImageFont
 
     try:
@@ -127,7 +137,7 @@ def _load_scale_font() -> ImageFont.ImageFont:
         font = _load_default_scale_font(
             "System font lookup utility 'fc-match' is not available: "
             f"{exc}",
-            font_size,
+            pixel_size,
         )
         logger.debug("fc-match not found while resolving '%s': %s", family, exc)
     except subprocess.CalledProcessError as exc:
@@ -141,21 +151,27 @@ def _load_scale_font() -> ImageFont.ImageFont:
         )
         if stderr:
             reason = f"{reason}: {stderr}"
-        font = _load_default_scale_font(reason, font_size)
+        font = _load_default_scale_font(reason, pixel_size)
     else:
         font_path = res.stdout.strip()
         if not font_path:
             font = _load_default_scale_font(
                 f"System font lookup returned an empty path for '{family}'",
-                font_size,
+                pixel_size,
             )
         else:
             try:
-                font = ImageFont.truetype(font_path, font_size)
+                font = ImageFont.truetype(font_path, pixel_size)
+                logger.debug(
+                    "Loaded scale bar font '%s' at %d px from '%s'",
+                    family,
+                    pixel_size,
+                    font_path,
+                )
             except OSError as exc:
                 font = _load_default_scale_font(
                     f"Failed to load system font '{font_path}': {exc}",
-                    font_size,
+                    pixel_size,
                 )
                 logger.debug("Unable to load font '%s': %s", font_path, exc)
 


### PR DESCRIPTION
## Summary
- clone the application font, apply the same TEXT_SCALE logic as the preview, and use Qt font metrics to derive the pixel height passed to Pillow when loading the scale bar font
- log the resolved pixel size and update default font handling to work with pixel units
- extend the scale bar tests to compare Qt font metrics with the rendered bitmap height and ensure the mu character remains visible with the updated scaling

## Testing
- pytest microstage_app/tests/test_scale_bar.py

------
https://chatgpt.com/codex/tasks/task_e_68c9db7b52888324acfcee15ab2b1234