### PR TITLE
Ensure SpectroscopyModeWizard uses consistent button ordering

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -868,6 +868,15 @@ class SpectroscopyModeWizard(QtWidgets.QWizard):
         self.setModal(False)
         self.setWindowModality(QtCore.Qt.NonModal)
         self.setOption(QtWidgets.QWizard.NoBackButtonOnStartPage)
+        self.setButtonLayout(
+            [
+                QtWidgets.QWizard.Stretch,
+                QtWidgets.QWizard.BackButton,
+                QtWidgets.QWizard.NextButton,
+                QtWidgets.QWizard.FinishButton,
+                QtWidgets.QWizard.CancelButton,
+            ]
+        )
         self._build_pages()
 
     def _build_pages(self) -> None:


### PR DESCRIPTION
## Summary
- set SpectroscopyModeWizard button layout to keep Back before Next while still showing Finish/Cancel

## Testing
- python -m pytest tests/test_spectroscopy_integration.py -k wizard -q *(fails: missing libGL in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69361761b7048324861d83721779ef99)