### PR TITLE
Refactor spectroscopy charts to shared helper

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -8,6 +8,7 @@ from PySide6 import QtCharts, QtCore, QtGui, QtWidgets
 
 from ..spectroscopy import processing
 from ..spectroscopy.session import SpectroscopySession
+from .spectrum_charts import SpectrumChartView, create_spectrum_chart
 
 CaptureCallable = Callable[[str, float, int], Optional[np.ndarray]]
 
@@ -313,20 +314,12 @@ class CapturePage(BaseWizardPage):
         self._refresh_live_chart()
         self._refresh_stored_chart()
 
-    def _build_chart(self) -> tuple[QtCharts.QChart, QtCharts.QChartView, QtCharts.QValueAxis, QtCharts.QValueAxis]:
-        chart = QtCharts.QChart()
-        chart.setAnimationOptions(QtCharts.QChart.NoAnimation)
-        chart.legend().setVisible(True)
-        chart.setMargins(QtCore.QMargins(6, 6, 6, 6))
-        x_axis = QtCharts.QValueAxis()
-        y_axis = QtCharts.QValueAxis()
-        x_axis.setTitleText(self._x_axis_title())
-        y_axis.setTitleText(self._y_axis_title())
-        chart.addAxis(x_axis, QtCore.Qt.AlignBottom)
-        chart.addAxis(y_axis, QtCore.Qt.AlignLeft)
-        view = QtCharts.QChartView(chart)
-        view.setRenderHint(QtGui.QPainter.Antialiasing)
-        return chart, view, x_axis, y_axis
+    def _build_chart(self) -> tuple[QtCharts.QChart, SpectrumChartView, QtCharts.QValueAxis, QtCharts.QValueAxis]:
+        return create_spectrum_chart(
+            x_title=self._x_axis_title(),
+            y_title=self._y_axis_title(),
+            legend_visible=True,
+        )
 
     def _x_axis_title(self) -> str:
         return "Raman shift (cm⁻¹)" if self.wizard_ref.mode == "Raman" else "Wavelength (nm)"
@@ -816,18 +809,17 @@ class ResultsPage(BaseWizardPage):
         super().__init__(wizard)
         self.setTitle("Results and overlays")
         layout = QtWidgets.QVBoxLayout(self)
-        self.chart = QtCharts.QChart()
-        self.chart.setAnimationOptions(QtCharts.QChart.NoAnimation)
-        self.chart.legend().setVisible(True)
-        self.x_axis = QtCharts.QValueAxis()
-        self.y_axis = QtCharts.QValueAxis()
-        self.chart.addAxis(self.x_axis, QtCore.Qt.AlignBottom)
-        self.chart.addAxis(self.y_axis, QtCore.Qt.AlignLeft)
-        self.x_axis.setTitleText("Wavelength (nm)")
-        self.y_axis.setTitleText("Intensity")
+        (
+            self.chart,
+            self.chart_view,
+            self.x_axis,
+            self.y_axis,
+        ) = create_spectrum_chart(
+            x_title="Wavelength (nm)",
+            y_title="Intensity",
+            legend_visible=True,
+        )
         self.secondary_axis: Optional[QtCharts.QCategoryAxis] = None
-        self.chart_view = QtCharts.QChartView(self.chart)
-        self.chart_view.setRenderHint(QtGui.QPainter.Antialiasing)
         self.history_list = QtWidgets.QListWidget()
         self.history_list.itemChanged.connect(self._toggle_series)
         self.metrics = QtWidgets.QLabel("No metrics computed yet.")

--- a/microstage_app/ui/spectroscopy_window.py
+++ b/microstage_app/ui/spectroscopy_window.py
@@ -36,6 +36,7 @@ from ..spectroscopy.processing import (
 )
 from ..spectroscopy.session import AcquisitionMetadata, SpectroscopySession
 from .spectroscopy_modes import ModeSelectorDialog, SpectroscopyModeWizard
+from .spectrum_charts import SpectrumChartView, create_spectrum_chart
 from ..utils.log import LOG, log
 from ..utils.workers import run_async
 import matplotlib.pyplot as plt
@@ -283,81 +284,6 @@ class ScrollDialog(QtWidgets.QDialog):
         buttons.rejected.connect(self.reject)
         buttons.accepted.connect(self.accept)
         layout.addWidget(buttons)
-
-
-class SpectrumChartView(QtCharts.QChartView):
-    cursorMoved = QtCore.Signal(float)
-    roiSelected = QtCore.Signal(float, float)
-
-    def __init__(self, chart: QtCharts.QChart, parent: Optional[QtWidgets.QWidget] = None):
-        super().__init__(chart, parent)
-        self.setRubberBand(QtCharts.QChartView.RectangleRubberBand)
-        self.setRenderHint(QtGui.QPainter.Antialiasing)
-        self._last_pos: Optional[QtCore.QPoint] = None
-        self._roi_origin: Optional[QtCore.QPoint] = None
-        self._roi_band = QtWidgets.QRubberBand(QtWidgets.QRubberBand.Rectangle, self)
-        self._vline = QtWidgets.QGraphicsLineItem()
-        self._vline.setPen(QtGui.QPen(QtGui.QColor("orange"), 1, QtCore.Qt.DotLine))
-        self.scene().addItem(self._vline)
-
-    def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:
-        if event.button() in (QtCore.Qt.MiddleButton,) or (
-            event.button() == QtCore.Qt.LeftButton and event.modifiers() & QtCore.Qt.ControlModifier
-        ):
-            self._last_pos = event.pos()
-        elif event.button() == QtCore.Qt.LeftButton and event.modifiers() & QtCore.Qt.ShiftModifier:
-            self._roi_origin = event.pos()
-            self._roi_band.setGeometry(QtCore.QRect(self._roi_origin, QtCore.QSize()))
-            self._roi_band.show()
-        super().mousePressEvent(event)
-
-    def mouseMoveEvent(self, event: QtGui.QMouseEvent) -> None:
-        if self._last_pos is not None:
-            delta = event.pos() - self._last_pos
-            self.chart().scroll(-delta.x(), delta.y())
-            self._last_pos = event.pos()
-        elif self._roi_origin is not None:
-            rect = QtCore.QRect(self._roi_origin, event.pos()).normalized()
-            self._roi_band.setGeometry(rect)
-        mapped = self.chart().mapToValue(event.position())
-        self._update_crosshair(mapped.x())
-        self.cursorMoved.emit(mapped.x())
-        super().mouseMoveEvent(event)
-
-    def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
-        if event.button() in (QtCore.Qt.MiddleButton, QtCore.Qt.LeftButton):
-            self._last_pos = None
-        if event.button() == QtCore.Qt.LeftButton and self._roi_origin is not None:
-            rect = QtCore.QRect(self._roi_origin, event.pos()).normalized()
-            self._roi_band.hide()
-            self._roi_origin = None
-            if rect.width() > 5:
-                p1 = self.chart().mapToValue(rect.topLeft())
-                p2 = self.chart().mapToValue(rect.bottomRight())
-                start, end = sorted([p1.x(), p2.x()])
-                self.roiSelected.emit(start, end)
-        super().mouseReleaseEvent(event)
-
-    def leaveEvent(self, event: QtCore.QEvent) -> None:
-        self._update_crosshair(None)
-        return super().leaveEvent(event)
-
-    def _update_crosshair(self, x: Optional[float]) -> None:
-        if x is None:
-            self._vline.setVisible(False)
-            return
-        chart = self.chart()
-        axis_y = chart.axisY()
-        if axis_y is None:
-            self._vline.setVisible(False)
-            return
-        plot_area = chart.plotArea()
-        top = chart.mapToPosition(QtCore.QPointF(x, axis_y.max()))
-        bottom = chart.mapToPosition(QtCore.QPointF(x, axis_y.min()))
-        self._vline.setLine(QtCore.QLineF(top, bottom))
-        self._vline.setVisible(plot_area.contains(top) or plot_area.contains(bottom))
-
-
 class SpectroscopyWindow(QtWidgets.QMainWindow):
     capture_requested = QtCore.Signal(CaptureJob)
     DEFAULT_WAVELENGTH_RANGE: tuple[float, float] = (410.0, 750.0)
@@ -410,25 +336,24 @@ class SpectroscopyWindow(QtWidgets.QMainWindow):
             QtGui.QColor("#8c564b"),
         ]
 
-        self._chart = QtCharts.QChart()
-        self._chart.setAnimationOptions(QtCharts.QChart.NoAnimation)
-        self._chart.legend().setVisible(False)
-        self._chart.setMargins(QtCore.QMargins(4, 4, 4, 4))
-        self._axis_x = QtCharts.QValueAxis()
-        self._axis_x.setTitleText("Wavelength (nm)")
-        self._axis_x.setRange(*self._default_wavelength_range)
-        self._chart.addAxis(self._axis_x, QtCore.Qt.AlignBottom)
-
-        self._axis_y = QtCharts.QValueAxis()
-        self._axis_y.setTitleText("Intensity (counts)")
-        self._axis_y.setRange(0.0, float(self._counts_max))
+        (
+            self._chart,
+            self._chart_view,
+            self._axis_x,
+            self._axis_y,
+        ) = create_spectrum_chart(
+            x_title="Wavelength (nm)",
+            y_title="Intensity (counts)",
+            legend_visible=False,
+            margins=QtCore.QMargins(4, 4, 4, 4),
+            x_range=self._default_wavelength_range,
+            y_range=(0.0, float(self._counts_max)),
+        )
         self._user_y_range = False
         self._suppress_y_range_tracking = False
         self._auto_scale_requested = True
-        self._chart.addAxis(self._axis_y, QtCore.Qt.AlignLeft)
         self._axis_y.rangeChanged.connect(self._on_axis_y_range_changed)
 
-        self._chart_view = SpectrumChartView(self._chart)
         self._traces: Dict[str, QtCharts.QLineSeries] = {}
         self._trace_meta: Dict[str, SpectrumTrace] = {}
         self._secondary_axis: Optional[QtCharts.QCategoryAxis] = None

--- a/microstage_app/ui/spectrum_charts.py
+++ b/microstage_app/ui/spectrum_charts.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from PySide6 import QtCharts, QtCore, QtGui, QtWidgets
+
+
+class SpectrumChartView(QtCharts.QChartView):
+    cursorMoved = QtCore.Signal(float)
+    roiSelected = QtCore.Signal(float, float)
+
+    def __init__(self, chart: QtCharts.QChart, parent: Optional[QtWidgets.QWidget] = None):
+        super().__init__(chart, parent)
+        self.setRubberBand(QtCharts.QChartView.RectangleRubberBand)
+        self.setRenderHint(QtGui.QPainter.Antialiasing)
+        self._last_pos: Optional[QtCore.QPoint] = None
+        self._roi_origin: Optional[QtCore.QPoint] = None
+        self._roi_band = QtWidgets.QRubberBand(QtWidgets.QRubberBand.Rectangle, self)
+        self._vline = QtWidgets.QGraphicsLineItem()
+        self._vline.setPen(QtGui.QPen(QtGui.QColor("orange"), 1, QtCore.Qt.DotLine))
+        self.scene().addItem(self._vline)
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:
+        if event.button() in (QtCore.Qt.MiddleButton,) or (
+            event.button() == QtCore.Qt.LeftButton and event.modifiers() & QtCore.Qt.ControlModifier
+        ):
+            self._last_pos = event.pos()
+        elif event.button() == QtCore.Qt.LeftButton and event.modifiers() & QtCore.Qt.ShiftModifier:
+            self._roi_origin = event.pos()
+            self._roi_band.setGeometry(QtCore.QRect(self._roi_origin, QtCore.QSize()))
+            self._roi_band.show()
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event: QtGui.QMouseEvent) -> None:
+        if self._last_pos is not None:
+            delta = event.pos() - self._last_pos
+            self.chart().scroll(-delta.x(), delta.y())
+            self._last_pos = event.pos()
+        elif self._roi_origin is not None:
+            rect = QtCore.QRect(self._roi_origin, event.pos()).normalized()
+            self._roi_band.setGeometry(rect)
+        mapped = self.chart().mapToValue(event.position())
+        self._update_crosshair(mapped.x())
+        self.cursorMoved.emit(mapped.x())
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
+        if event.button() in (QtCore.Qt.MiddleButton, QtCore.Qt.LeftButton):
+            self._last_pos = None
+        if event.button() == QtCore.Qt.LeftButton and self._roi_origin is not None:
+            rect = QtCore.QRect(self._roi_origin, event.pos()).normalized()
+            self._roi_band.hide()
+            self._roi_origin = None
+            if rect.width() > 5:
+                p1 = self.chart().mapToValue(rect.topLeft())
+                p2 = self.chart().mapToValue(rect.bottomRight())
+                start, end = sorted([p1.x(), p2.x()])
+                self.roiSelected.emit(start, end)
+        super().mouseReleaseEvent(event)
+
+    def leaveEvent(self, event: QtCore.QEvent) -> None:
+        self._update_crosshair(None)
+        return super().leaveEvent(event)
+
+    def _update_crosshair(self, x: Optional[float]) -> None:
+        if x is None:
+            self._vline.setVisible(False)
+            return
+        chart = self.chart()
+        axis_y = chart.axisY()
+        if axis_y is None:
+            self._vline.setVisible(False)
+            return
+        plot_area = chart.plotArea()
+        top = chart.mapToPosition(QtCore.QPointF(x, axis_y.max()))
+        bottom = chart.mapToPosition(QtCore.QPointF(x, axis_y.min()))
+        self._vline.setLine(QtCore.QLineF(top, bottom))
+        self._vline.setVisible(plot_area.contains(top) or plot_area.contains(bottom))
+
+
+def create_spectrum_chart(
+    *,
+    x_title: str = "Wavelength (nm)",
+    y_title: str = "Intensity (counts)",
+    legend_visible: bool = False,
+    margins: QtCore.QMargins = QtCore.QMargins(4, 4, 4, 4),
+    x_range: Optional[Tuple[float, float]] = None,
+    y_range: Optional[Tuple[float, float]] = None,
+) -> tuple[QtCharts.QChart, SpectrumChartView, QtCharts.QValueAxis, QtCharts.QValueAxis]:
+    chart = QtCharts.QChart()
+    chart.setAnimationOptions(QtCharts.QChart.NoAnimation)
+    chart.legend().setVisible(legend_visible)
+    chart.setMargins(margins)
+
+    x_axis = QtCharts.QValueAxis()
+    x_axis.setTitleText(x_title)
+    if x_range:
+        x_axis.setRange(*x_range)
+    chart.addAxis(x_axis, QtCore.Qt.AlignBottom)
+
+    y_axis = QtCharts.QValueAxis()
+    y_axis.setTitleText(y_title)
+    if y_range:
+        y_axis.setRange(*y_range)
+    chart.addAxis(y_axis, QtCore.Qt.AlignLeft)
+
+    view = SpectrumChartView(chart)
+    return chart, view, x_axis, y_axis


### PR DESCRIPTION
## Summary
- Extracted SpectrumChartView and shared chart-construction helper for spectroscopy views
- Updated spectroscopy window and wizard capture/result charts to use the centralized setup
- Ensured wizard charts inherit the same margins, axes, and interaction tools as the main window

## Testing
- python -m compileall microstage_app/ui/spectrum_charts.py microstage_app/ui/spectroscopy_modes.py microstage_app/ui/spectroscopy_window.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69369eb4c7148324a473432f34a96357)