### PR TITLE
Improve spectroscopy wizard label contrast

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -1076,6 +1076,18 @@ class SpectroscopyModeWizard(QtWidgets.QWizard):
                 QtWidgets.QWizard.CancelButton,
             ]
         )
+        self.setStyleSheet(
+            "\n".join(
+                [
+                    "QWizardPage QLabel {",
+                    "  color: palette(WindowText);",
+                    "}",
+                    "QWizardPage QGroupBox::title {",
+                    "  color: palette(WindowText);",
+                    "}",
+                ]
+            )
+        )
         self._build_pages()
 
     def _build_pages(self) -> None:
@@ -1172,4 +1184,3 @@ class SpectroscopyModeWizard(QtWidgets.QWizard):
     def accept(self) -> None:  # type: ignore[override]
         self._persist_params()
         super().accept()
-


### PR DESCRIPTION
### Motivation
- Labels and group box titles in the spectroscopy wizard (including the "Acquisition and wavelength setup" page) were not following the application palette and could be hard to read under the dark theme. 
- Ensure text on wizard pages uses the same `WindowText` palette color so labels remain legible across themes. 

### Description
- Added a page-level stylesheet in `SpectroscopyModeWizard.__init__` to force `QWizardPage QLabel` and `QWizardPage QGroupBox::title` to use `palette(WindowText)`.  
- Change applied in `microstage_app/ui/spectroscopy_modes.py` so all wizard pages built by `SpectroscopyModeWizard` inherit the improved label coloring.  
- This affects pages such as `AcquisitionSetupPage` and all subsequent wizard pages created by `_build_pages()`.

### Testing
- No automated tests were run as part of this change.  
- Changes were committed to the repository (`microstage_app/ui/spectroscopy_modes.py`) and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481c694a4883249d28e2f41fce067e)