### PR TITLE
Stack live and captured spectra vertically in capture wizard

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -236,7 +236,7 @@ class CapturePage(BaseWizardPage):
         else:
             self.preset_combo = None
         layout.addWidget(self.btn_capture)
-        charts_row = QtWidgets.QHBoxLayout()
+        charts_column = QtWidgets.QVBoxLayout()
         live_group = QtWidgets.QGroupBox("Live spectrum")
         live_layout = QtWidgets.QVBoxLayout(live_group)
         (
@@ -259,9 +259,9 @@ class CapturePage(BaseWizardPage):
         self.stored_status = QtWidgets.QLabel("No capture yet.")
         stored_layout.addWidget(self.stored_chart_view)
         stored_layout.addWidget(self.stored_status)
-        charts_row.addWidget(live_group, 1)
-        charts_row.addWidget(stored_group, 1)
-        layout.addLayout(charts_row)
+        charts_column.addWidget(live_group, 1)
+        charts_column.addWidget(stored_group, 1)
+        layout.addLayout(charts_column)
         layout.addStretch(1)
 
         self.session.spectra_changed.connect(self._on_session_spectrum_changed)
@@ -270,6 +270,8 @@ class CapturePage(BaseWizardPage):
         self._live_timer.setInterval(750)
         self._live_timer.timeout.connect(self._refresh_live_chart)
         self._live_timer.start()
+        self._live_capture_in_flight = False
+        self._live_spectrum: Optional[np.ndarray] = None
 
     def _capture(self) -> None:
         self.wizard_ref.apply_preset_for_step(self.capture_key)
@@ -328,7 +330,20 @@ class CapturePage(BaseWizardPage):
         return "Intensity (counts)"
 
     def _refresh_live_chart(self) -> None:
-        data = self.session.raw_spectrum or self.session.reference_spectrum or self.session.dark_spectrum
+        if self._live_capture_in_flight:
+            return
+        params = self.wizard_ref.mode_params
+        integration = float(params.get("integration", 10.0))
+        averages = int(params.get("averages", 1))
+        self._live_capture_in_flight = True
+        try:
+            data = self.wizard_ref.capture_callback("preview", integration, averages)
+        finally:
+            self._live_capture_in_flight = False
+        if data is None:
+            data = self._live_spectrum
+        else:
+            self._live_spectrum = data
         label = "Live"
         color = QtGui.QColor("deepskyblue")
         self._plot_chart(self.live_chart, self.live_x_axis, self.live_y_axis, self.live_status, label, data, color)
@@ -388,11 +403,25 @@ class CapturePage(BaseWizardPage):
             ymin, ymax = 0.0, 1.0
         if ymin == ymax:
             ymax += 1.0
-        x_axis.setRange(float(np.nanmin(wl)), float(np.nanmax(wl)))
+        x_range = self._wavelength_range()
+        if x_range is None:
+            x_range = (float(np.nanmin(wl)), float(np.nanmax(wl)))
+        x_axis.setRange(*x_range)
         y_axis.setRange(ymin, ymax)
         x_axis.setTitleText(self._x_axis_title())
         y_axis.setTitleText(self._y_axis_title())
         status_label.setText("")
+
+    def _wavelength_range(self) -> Optional[Tuple[float, float]]:
+        range_vals = self.wizard_ref.mode_params.get("wavelength_range")
+        if isinstance(range_vals, (list, tuple)) and len(range_vals) == 2:
+            try:
+                low, high = float(range_vals[0]), float(range_vals[1])
+            except (TypeError, ValueError):
+                return None
+            if low < high:
+                return low, high
+        return None
 
     def _sync_axes(self) -> None:
         self.live_x_axis.setTitleText(self._x_axis_title())

--- a/microstage_app/ui/spectroscopy_window.py
+++ b/microstage_app/ui/spectroscopy_window.py
@@ -2128,20 +2128,21 @@ class SpectroscopyWindow(QtWidgets.QMainWindow):
                 dev.set_integration_time_ms(integration)
                 dev.set_averages(averages)
                 spectrum = dev.capture()
-            ts = time.time()
-            self._record_capture(
-                kind,
-                spectrum,
-                {
-                    "integration_ms": float(integration),
-                    "averages": int(averages),
-                    "smoothing": int(self.smoothing_spin.value()),
-                    "device_id": self._current_device_id(),
-                    "mode": self.current_mode,
-                    "timestamp": ts,
-                },
-                raw_data=spectrum,
-            )
+            if kind != "preview":
+                ts = time.time()
+                self._record_capture(
+                    kind,
+                    spectrum,
+                    {
+                        "integration_ms": float(integration),
+                        "averages": int(averages),
+                        "smoothing": int(self.smoothing_spin.value()),
+                        "device_id": self._current_device_id(),
+                        "mode": self.current_mode,
+                        "timestamp": ts,
+                    },
+                    raw_data=spectrum,
+                )
             return spectrum
         except Exception as exc:
             self.status_message.setText(f"Capture failed: {exc}")


### PR DESCRIPTION
### Motivation
- Make the Capture pages show the live preview and the stored capture stacked vertically for clearer UX.
- Drive the top plot from a live preview acquisition that respects the wizard acquisition settings (`integration`, `averages`).
- Avoid recording those preview captures into the normal capture history or session metadata.
- Ensure plotted x-axis honors any configured wavelength range from the wizard (`wavelength_range`).

### Description
- Replaced the side-by-side chart layout with a vertical stack by switching from `QHBoxLayout` to `QVBoxLayout` in `CapturePage` and adding the live and stored `QGroupBox` widgets to that column layout.
- Live preview now performs a preview acquisition via the wizard's `capture_callback` using kind `"preview"`, and the preview uses `mode_params` (`integration`, `averages`) to drive the device.
- Added a guard (`_live_capture_in_flight`) and cached `_live_spectrum` to avoid re-entrant preview captures and to fall back to the last preview if a capture fails.
- Prevented preview captures from being recorded by updating `_wizard_capture` to skip `self._record_capture` when `kind == "preview"` and added a `_wavelength_range` helper to respect `wavelength_range` when setting the x-axis range.

### Testing
- No automated tests were run for this change.
- Code was type-checked / reviewed locally as part of the edit and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481d9fb5088324a1672bbab976f52a)