### PR TITLE
Fix QAction type checks for PySide6

### DIFF
--- a/microstage_app/ui/main_window.py
+++ b/microstage_app/ui/main_window.py
@@ -660,7 +660,7 @@ class MainWindow(QtWidgets.QMainWindow):
             elif isinstance(w, QtWidgets.QCheckBox):
                 val = self.profiles.get(path, w.isChecked(), expected_type=bool)
                 w.setChecked(val)
-            elif isinstance(w, QtWidgets.QAction):
+            elif isinstance(w, QtGui.QAction):
                 val = self.profiles.get(path, w.isChecked(), expected_type=bool)
                 w.setChecked(val)
             elif isinstance(w, QtWidgets.QComboBox):
@@ -4259,7 +4259,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 val = w.value()
             elif isinstance(w, QtWidgets.QCheckBox):
                 val = w.isChecked()
-            elif isinstance(w, QtWidgets.QAction):
+            elif isinstance(w, QtGui.QAction):
                 val = w.isChecked()
             elif isinstance(w, QtWidgets.QComboBox):
                 data = w.currentData()


### PR DESCRIPTION
### Motivation
- The app crashed on startup with `AttributeError: module 'PySide6.QtWidgets' has no attribute 'QAction'` when loading persisted UI state.
- The persisted widget load/save logic used `isinstance(..., QtWidgets.QAction)` which is incorrect for PySide6.

### Description
- Replace `QtWidgets.QAction` with `QtGui.QAction` in the persisted widget load and close handlers.
- Changes applied in `microstage_app/ui/main_window.py` to fix the type checks so QAction instances are recognized under PySide6.

### Testing
- No automated tests were executed as part of this change.
- The fix is limited to two `isinstance` checks and should prevent the reported startup `AttributeError`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482574ffa88324a6c8dc97913de4da)