### PR TITLE
Guard acquisition setup initialization

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -73,6 +73,7 @@ def _attach_series(
 class AcquisitionSetupPage(BaseWizardPage):
     def __init__(self, wizard: 'SpectroscopyModeWizard') -> None:
         super().__init__(wizard)
+        self._initializing = True
         self.setTitle("Acquisition and wavelength setup")
         layout = QtWidgets.QVBoxLayout(self)
 
@@ -137,12 +138,15 @@ class AcquisitionSetupPage(BaseWizardPage):
 
         wizard.session.spectra_changed.connect(self._refresh_chart)
         wizard.session.wavelengths_changed.connect(lambda _: self._refresh_chart())
+        self._initializing = False
         self._sync_params()
 
     def initializePage(self) -> None:  # type: ignore[override]
         self._refresh_chart()
 
     def _on_param_changed(self) -> None:
+        if self._initializing:
+            return
         self._sync_params()
         self.wizard_ref.invalidate_captures()
         self.mark_dirty()


### PR DESCRIPTION
### Motivation
- Prevent repeated chart refreshes triggered by startup `setValue()` calls in `AcquisitionSetupPage.__init__` that cause a refresh storm.
- Ensure initial acquisition and wavelength values are applied without invoking live-update handlers prematurely.
- Preserve live-update behavior for user-driven changes after initialization completes.

### Description
- Added an initialization flag `self._initializing` at the start of `AcquisitionSetupPage.__init__` in `microstage_app/ui/spectroscopy_modes.py`.
- Suppressed parameter-change handling by returning early from `_on_param_changed` when `self._initializing` is true.
- Set `self._initializing = False` after initial values and `wizard.session` wavelengths are applied and then call `_sync_params()` once to populate the chart.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482b3b5dc08324a81c9e771077e4e6)