### PR TITLE
Limit live preview updates to active wizard pages

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -273,7 +273,6 @@ class CapturePage(BaseWizardPage):
         self._live_timer = QtCore.QTimer(self)
         self._live_timer.setInterval(750)
         self._live_timer.timeout.connect(self._refresh_live_chart)
-        self._live_timer.start()
         self._live_capture_in_flight = False
         self._live_spectrum: Optional[np.ndarray] = None
 
@@ -313,8 +312,14 @@ class CapturePage(BaseWizardPage):
 
     def initializePage(self) -> None:  # type: ignore[override]
         self._sync_axes()
+        if not self._live_timer.isActive():
+            self._live_timer.start()
         self._refresh_live_chart()
         self._refresh_stored_chart()
+
+    def cleanupPage(self) -> None:  # type: ignore[override]
+        if self._live_timer.isActive():
+            self._live_timer.stop()
 
     def _on_session_spectrum_changed(self) -> None:
         self._refresh_live_chart()


### PR DESCRIPTION
### Motivation
- Opening the acquisition wizard (e.g. Absorbance) was triggering background live captures and chart rebuilds that slowed setup performance.
- The live preview `QTimer` was started unconditionally when a capture page was constructed, causing sampling and smoothing work even when the page was not visible.

### Description
- Delay starting the live-preview timer by removing the unconditional `self._live_timer.start()` from the constructor and starting it in `initializePage` only when the page becomes active.
- Stop the live-preview timer in `cleanupPage` so background captures cease when leaving the page.
- Changes are contained in `microstage_app/ui/spectroscopy_modes.py` and center on the `_live_timer` lifecycle for `CapturePage`.

### Testing
- No automated tests were run on this change.
- (No additional automated validation was requested.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482871a97083249df796a6613f6af8)