### PR TITLE
Synchronize spectrometer disconnect with acquisition lock

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -317,11 +317,12 @@ class SpectrometerManager(QtCore.QObject):
         targets = [descriptor] if descriptor else list(self._active.keys())
         for desc in targets:
             device = self._active.pop(desc, None)
-            self._locks.pop(desc, None)
+            lock = self._locks.get(desc)
             if device is None:
                 self.device_connected.emit(desc, None)
                 continue
             try:
+                locker = QtCore.QMutexLocker(lock) if lock is not None else None
                 try:
                     logger.info(
                         "[thread=%s] Disconnecting spectrometer via %s: %s (%s)",
@@ -339,7 +340,11 @@ class SpectrometerManager(QtCore.QObject):
                     )
                 except BaseException as exc:  # pragma: no cover - defensive
                     logger.warning("Failed to disconnect spectrometer %s: %s", desc.label(), exc)
+                finally:
+                    if locker is not None:
+                        locker.unlock()
             finally:
+                self._locks.pop(desc, None)
                 self.device_connected.emit(desc, None)
         if descriptor is None:
             self._last_active = None


### PR DESCRIPTION
### Motivation
- Prevent races where calling `disconnect` while a capture is in progress can cause native backend crashes (e.g. seabreeze). 
- Make `disconnect` coordinated with the same acquisition mutex used by `CaptureWorker.perform_capture` so no capture can be operating on the device while it is being torn down. 
- The previous logic removed the lock entry before calling `device.disconnect()`, which allowed concurrent captures to run during disconnect. 
- Hold the acquisition mutex across the `disconnect` call to make the operation atomic with respect to captures.

### Description
- Modified `SpectrometerManager.disconnect` to obtain the per-descriptor lock via `self._locks.get(desc)` and hold it with `QtCore.QMutexLocker` while calling `device.disconnect()`.
- Ensure the lock is explicitly released after `device.disconnect()` completes and only then remove the lock entry with `self._locks.pop(desc, None)`.
- Preserve existing signaling (`device_connected.emit`) and monitor resume behavior while preventing concurrent capture/disconnect access.
- Small refactor to fetch the lock before disconnect instead of popping it immediately so the lock can be held for the duration of the teardown.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694830ffeaec8324b8d86d8653fce5be)