### PR TITLE
Reset spectroscopy mode state to Counts before launching mode wizard

### DIFF
--- a/microstage_app/ui/spectroscopy_window.py
+++ b/microstage_app/ui/spectroscopy_window.py
@@ -2024,9 +2024,26 @@ class SpectroscopyWindow(QtWidgets.QMainWindow):
         img.save(path)
 
     # ------------------------------------------------------------------
+    def _reset_to_counts_mode(self) -> None:
+        self.current_mode = ""
+        self.mode_params = {}
+        self.session.set_mode_params()
+        self._default_wavelength_range = self.DEFAULT_WAVELENGTH_RANGE
+        self._axis_ranges["x"] = (
+            float(self._default_wavelength_range[0]),
+            float(self._default_wavelength_range[1]),
+        )
+        if self._axis_x:
+            self._axis_x.setRange(*self._axis_ranges["x"])
+        self._update_mode_label()
+        self._update_session_context()
+        self._reset_y_axis_range()
+
     def _open_modes_dialog(self) -> None:
         dlg = ModeSelectorDialog(self.MODES, parent=self)
         if dlg.exec() == QtWidgets.QDialog.Accepted and dlg.selected_mode:
+            if not self._is_counts_mode():
+                self._reset_to_counts_mode()
             self._launch_wizard(dlg.selected_mode)
 
     def _launch_wizard(self, mode: str) -> None:


### PR DESCRIPTION
### Motivation
- Ensure the live plot and `SpectroscopySession` return to unprocessed counts while a mode wizard is open. 
- Prevent previously selected mode parameters (including wavelength range and y-axis overrides) from affecting the wizard preview and capture flows. 
- Restore UI text and axis state so labels and axis ranges reflect counts mode before changing modes.

### Description
- Add helper `def _reset_to_counts_mode(self)` that sets `self.current_mode` to `""`, clears `self.mode_params`, and calls `self.session.set_mode_params()`.
- Restore `self._default_wavelength_range` to `DEFAULT_WAVELENGTH_RANGE` and update `self._axis_ranges["x"]` and `self._axis_x` range if present.
- Refresh the UI and session by calling `self._update_mode_label()`, `self._update_session_context()`, and `self._reset_y_axis_range()` from the helper.
- Call the helper from `_open_modes_dialog` before `_launch_wizard` when `not self._is_counts_mode()` so the wizard opens with counts/unprocessed state.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948319c0a3483249119b742601d9f2e)