### PR TITLE
Fix spectroscopy wizard text contrast

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -928,10 +928,22 @@ class SpectroscopyModeWizard(QtWidgets.QWizard):
             "\n".join(
                 [
                     "QWizardPage QLabel {",
-                    "  color: palette(WindowText);",
+                    "  color: #000000;",
                     "}",
                     "QWizardPage QGroupBox::title {",
-                    "  color: palette(WindowText);",
+                    "  color: #000000;",
+                    "}",
+                    "QWizardPage QAbstractButton {",
+                    "  color: #000000;",
+                    "}",
+                    "QWizardPage QAbstractSpinBox {",
+                    "  color: #000000;",
+                    "}",
+                    "QWizardPage QLineEdit {",
+                    "  color: #000000;",
+                    "}",
+                    "QWizardPage QComboBox {",
+                    "  color: #000000;",
                     "}",
                 ]
             )


### PR DESCRIPTION
### Motivation
- The acquisition and wavelength setup wizard displayed white text on a light background, making labels and controls unreadable.
- The change forces readable, high-contrast text for wizard pages regardless of platform/theme.
- Improve usability for spectroscopy modes like `Absorbance`, `Transmittance`, and others that use the wizard.

### Description
- Updated the stylesheet for `SpectroscopyModeWizard` in `microstage_app/ui/spectroscopy_modes.py` to enforce black text color.
- Replaced `palette(WindowText)` usage for `QWizardPage QLabel` and `QGroupBox::title` with an explicit `#000000` color.
- Added explicit color rules forcing `#000000` for `QWizardPage QAbstractButton`, `QWizardPage QAbstractSpinBox`, `QWizardPage QLineEdit`, and `QWizardPage QComboBox`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483527ba608324b7b2104fedb2a4fa)