### PR TITLE
Make acquisition/wavelength spinbox text white

### DIFF
--- a/microstage_app/ui/spectroscopy_modes.py
+++ b/microstage_app/ui/spectroscopy_modes.py
@@ -86,6 +86,7 @@ class AcquisitionSetupPage(BaseWizardPage):
         for spin in (self.min_spin, self.max_spin):
             spin.setSuffix(" nm")
             spin.setRange(0, 2000)
+            spin.setStyleSheet("QAbstractSpinBox { color: white; }")
             spin.valueChanged.connect(self._on_param_changed)
         wl_form.addRow("Min wavelength", self.min_spin)
         wl_form.addRow("Max wavelength", self.max_spin)
@@ -103,6 +104,7 @@ class AcquisitionSetupPage(BaseWizardPage):
         self.smoothing.setRange(1, 101)
         self.smoothing.setValue(wizard.initial_acquisition.get("smoothing", 5))
         for widget in (self.integration, self.averages, self.smoothing):
+            widget.setStyleSheet("QAbstractSpinBox { color: white; }")
             widget.valueChanged.connect(self._on_param_changed)
         acq_form.addRow("Integration time", self.integration)
         acq_form.addRow("Averages", self.averages)


### PR DESCRIPTION
### Motivation
- The acquisition and wavelength setup dialog uses dark backgrounds and the spinbox text was not readable, so the spinbox text color needs to be set to white.
- This change targets the UI only and does not alter acquisition logic or behavior.

### Description
- Set the spinbox text color to white by calling `setStyleSheet("QAbstractSpinBox { color: white; }")` for wavelength spinboxes (`min_spin`, `max_spin`) in `AcquisitionSetupPage`.
- Apply the same `setStyleSheet` to acquisition spinboxes (`integration`, `averages`, `smoothing`).
- Change occurs in `microstage_app/ui/spectroscopy_modes.py` and is limited to two small insertions that only affect presentation.

### Testing
- No automated tests were executed for this change.
- The change is strictly UI styling and does not include functional test coverage in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694839875ec08324822ed9a947d6101e)