### PR TITLE
Avoid legend marker disconnect warnings

### DIFF
--- a/microstage_app/ui/spectroscopy_window.py
+++ b/microstage_app/ui/spectroscopy_window.py
@@ -835,12 +835,17 @@ class SpectroscopyWindow(QtWidgets.QMainWindow):
 
     # ------------------------------------------------------------------
     def _install_legend_handlers(self) -> None:
-        for marker in self._chart.legend().markers():
-            try:
+        if not hasattr(self, "_legend_marker_connections"):
+            self._legend_marker_connections = set()
+        markers = list(self._chart.legend().markers())
+        active_markers = set(markers)
+        self._legend_marker_connections.intersection_update(active_markers)
+        for marker in markers:
+            if marker in self._legend_marker_connections:
                 marker.clicked.disconnect()
-            except Exception:
-                pass
+                self._legend_marker_connections.discard(marker)
             marker.clicked.connect(lambda checked=False, m=marker: self._toggle_series(m))
+            self._legend_marker_connections.add(marker)
 
     def _toggle_series(self, marker: QtCharts.QLegendMarker) -> None:
         series = marker.series()


### PR DESCRIPTION
### Motivation
- Prevent `RuntimeWarning` or exceptions when calling `marker.clicked.disconnect()` for markers that are not connected.
- Ensure legend handler refresh (e.g. on Finish or when traces change) does not emit warnings.
- Prune stale marker references when the legend is updated so we only manage currently-present markers.

### Description
- Added a `_legend_marker_connections` set to track markers that have been connected to the handler. 
- Collect current markers via `markers = list(self._chart.legend().markers())` and compute `active_markers` to prune stale entries with `intersection_update`.
- Only call `disconnect()` for markers present in `_legend_marker_connections`, and update the set when disconnecting and after connecting.
- Replaced the broad `try/except` around `disconnect()` with explicit tracking to avoid spurious warnings while still attaching the click handler via `marker.clicked.connect(...)`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483ec6325c83249072078ada8f2715)