### PR TITLE
Make spectrometer refresh asynchronous and surface status to UI

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -69,6 +69,7 @@ class SpectrometerManager(QtCore.QObject):
     devices_changed = QtCore.Signal(list)
     device_connected = QtCore.Signal(object, object)
     connect_failed = QtCore.Signal(object, str)
+    refresh_completed = QtCore.Signal(bool, str)
 
     def __init__(
         self,
@@ -90,6 +91,13 @@ class SpectrometerManager(QtCore.QObject):
         self._poll_worker: Optional[QtCore.QObject] = None
         self._poll_in_flight = False
         self._monitor_paused_for_active = False
+        self._refresh_thread: Optional[QtCore.QThread] = None
+        self._refresh_worker: Optional[QtCore.QObject] = None
+        self._refresh_timeout_timer: Optional[QtCore.QTimer] = None
+        self._refresh_in_flight = False
+        self._refresh_token: Optional[object] = None
+        self._refresh_was_paused = False
+        self._refresh_start_monitoring = False
         self._monitor_timer = QtCore.QTimer(self)
         self._monitor_timer.setInterval(2000)
         self._monitor_timer.timeout.connect(self._poll_devices)
@@ -170,6 +178,14 @@ class SpectrometerManager(QtCore.QObject):
             except BaseException:  # pragma: no cover - defensive
                 logger.error("Failed to stop spectrometer poll thread:\n%s", traceback.format_exc())
 
+    def _reset_refresh_state(self) -> None:
+        self._refresh_thread = None
+        self._refresh_worker = None
+        self._refresh_in_flight = False
+        self._refresh_token = None
+        self._refresh_was_paused = False
+        self._refresh_start_monitoring = False
+
     def _poll_devices(self) -> None:
         if self._monitor_paused_for_active:
             return
@@ -219,6 +235,78 @@ class SpectrometerManager(QtCore.QObject):
         elif not start_monitoring:
             self.stop_monitoring()
         return list(self._devices)
+
+    def refresh_async(self, *, start_monitoring: bool = False, timeout_ms: int = 10000) -> bool:
+        if self._refresh_in_flight:
+            return False
+        self._refresh_in_flight = True
+        self._refresh_was_paused = self._monitor_paused_for_active
+        self._refresh_start_monitoring = start_monitoring
+        if self._refresh_was_paused:
+            self._monitor_paused_for_active = False
+        if start_monitoring:
+            self.start_monitoring(force=True)
+        token = object()
+        self._refresh_token = token
+        try:
+            thread, worker = run_async(self._enumerate_devices, parent=self)
+            self._refresh_thread = thread
+            self._refresh_worker = worker
+            worker.finished.connect(
+                lambda devices, err, token=token: self._on_refresh_finished(token, devices, err)
+            )
+        except BaseException:
+            logger.error("Unhandled error starting spectrometer refresh:\n%s", traceback.format_exc())
+            self._reset_refresh_state()
+            self.refresh_completed.emit(False, "Failed to start refresh")
+            return True
+        if timeout_ms > 0:
+            if self._refresh_timeout_timer is None:
+                self._refresh_timeout_timer = QtCore.QTimer(self)
+                self._refresh_timeout_timer.setSingleShot(True)
+            else:
+                try:
+                    self._refresh_timeout_timer.timeout.disconnect()
+                except (TypeError, RuntimeError):
+                    pass
+            self._refresh_timeout_timer.timeout.connect(
+                lambda token=token: self._on_refresh_timeout(token)
+            )
+            self._refresh_timeout_timer.start(timeout_ms)
+        return True
+
+    def _finalize_refresh(self, success: bool, message: str) -> None:
+        if self._refresh_was_paused and self._active:
+            self._pause_monitoring_for_active_use()
+        elif not self._refresh_start_monitoring:
+            self.stop_monitoring()
+        self.refresh_completed.emit(success, message)
+        self._reset_refresh_state()
+
+    def _on_refresh_timeout(self, token: object) -> None:
+        if token != self._refresh_token or not self._refresh_in_flight:
+            return
+        logger.warning("Spectrometer refresh timed out")
+        self._finalize_refresh(False, "Device refresh timed out")
+
+    @QtCore.Slot(object, object)
+    def _on_refresh_finished(self, token: object, devices, err) -> None:
+        if token != self._refresh_token:
+            return
+        if self._refresh_timeout_timer is not None:
+            self._refresh_timeout_timer.stop()
+        if err:
+            logger.error("Spectrometer refresh failed: %s\n%s", err, _format_exception(err))
+            message = str(err) or "Device refresh failed"
+            self._finalize_refresh(False, message)
+            return
+        try:
+            self._update_devices(devices)
+        except BaseException:
+            logger.error("Unhandled error applying refreshed devices:\n%s", traceback.format_exc())
+            self._finalize_refresh(False, "Device refresh failed")
+            return
+        self._finalize_refresh(True, "Device refresh complete")
 
     def connect(self, descriptor: SpectrometerDescriptor) -> Optional[SpectrometerDevice]:
         if descriptor in self._active:

--- a/microstage_app/ui/spectroscopy_window.py
+++ b/microstage_app/ui/spectroscopy_window.py
@@ -708,6 +708,7 @@ class SpectroscopyWindow(QtWidgets.QMainWindow):
         self.spectrometer_manager.devices_changed.connect(self._on_devices_changed)
         self.spectrometer_manager.device_connected.connect(self._on_device_connected)
         self.spectrometer_manager.connect_failed.connect(self._on_connect_failed)
+        self.spectrometer_manager.refresh_completed.connect(self._on_refresh_completed)
         self.session.validity_changed.connect(self._refresh_validity_state)
 
         self.counts_max_slider.valueChanged.connect(self.counts_max_spin.setValue)
@@ -1018,9 +1019,22 @@ class SpectroscopyWindow(QtWidgets.QMainWindow):
             self.profiles.save()
 
     def _refresh_devices(self) -> None:
-        devices = self.spectrometer_manager.refresh(start_monitoring=False)
-        self._last_refresh_successful = True
-        self._populate_devices(devices)
+        if not self.btn_refresh.isEnabled():
+            return
+        self.btn_refresh.setEnabled(False)
+        self.status_message.setText("Refreshing spectrometers…")
+        started = self.spectrometer_manager.refresh_async(start_monitoring=False, timeout_ms=10000)
+        if not started:
+            self.btn_refresh.setEnabled(True)
+            self.status_message.setText("Refresh already in progress")
+
+    def _on_refresh_completed(self, success: bool, message: str) -> None:
+        self.btn_refresh.setEnabled(True)
+        self._last_refresh_successful = success
+        if success:
+            self.status_message.setText(message or "Device refresh complete")
+        else:
+            self.status_message.setText(message or "Device refresh failed")
         self._apply_monitoring_state()
 
     def _on_monitor_toggled(self, checked: bool) -> None:


### PR DESCRIPTION
### Motivation
- Prevent UI blocking during device enumeration and provide clear feedback when a refresh is in progress or fails.
- Ensure background polling/monitoring behavior respects manual refresh state and active device use.
- Surface errors and timeouts from device enumeration to the UI so `_last_refresh_successful` reflects real outcomes.

### Description
- Add `refresh_completed` signal and a new non-blocking `refresh_async()` on `SpectrometerManager` that enumerates devices on a worker thread via `run_async`, supports a timeout, and emits completion back on the main thread.
- Implement tokenized refresh state, timeout handling, and robust error catching in `SpectrometerManager` so failures/timeouts call `refresh_completed(False, ...)` and success calls `refresh_completed(True, ...)`.
- Wire the spectroscopy window to disable the `Refresh` button while a refresh is in flight, show status messages, and handle `refresh_completed` to set `_last_refresh_successful` and re-enable the button.
- Update monitoring/polling state handling so the refresh flow pauses/resumes monitoring appropriately when devices are active.

### Testing
- No automated tests were run for this change.
- Functionality was exercised via the application flow in the rollout but no CI test suite was executed.
- (No unit tests added in this change.)
- Further automated tests should be added to validate timeout/error paths and UI signal handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948460c962083249db2b157eca6ddc0)