### PR TITLE
Improve async spectrometer refresh handling

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -257,8 +257,7 @@ class SpectrometerManager(QtCore.QObject):
             )
         except BaseException:
             logger.error("Unhandled error starting spectrometer refresh:\n%s", traceback.format_exc())
-            self._reset_refresh_state()
-            self.refresh_completed.emit(False, "Failed to start refresh")
+            self._finalize_refresh(False, "Failed to start refresh")
             return True
         if timeout_ms > 0:
             if self._refresh_timeout_timer is None:

--- a/microstage_app/ui/spectroscopy_window.py
+++ b/microstage_app/ui/spectroscopy_window.py
@@ -1025,7 +1025,6 @@ class SpectroscopyWindow(QtWidgets.QMainWindow):
         self.status_message.setText("Refreshing spectrometers…")
         started = self.spectrometer_manager.refresh_async(start_monitoring=False, timeout_ms=10000)
         if not started:
-            self.btn_refresh.setEnabled(True)
             self.status_message.setText("Refresh already in progress")
 
     def _on_refresh_completed(self, success: bool, message: str) -> None:


### PR DESCRIPTION
### Motivation
- Ensure spectrometer refresh start failures go through the normal finalization path so monitoring state is restored and completion is emitted.
- Keep the UI Refresh button disabled while an async refresh is running to avoid confusing re-enables.
- Centralize refresh failure handling to produce a consistent user-visible status message.
- Avoid duplicated/partial tear-down logic when starting an async refresh fails.

### Description
- In `microstage_app/spectroscopy/devices.py` call `_finalize_refresh(False, "Failed to start refresh")` on refresh startup failure so the shared finalization logic runs and `refresh_completed` is emitted.
- In `microstage_app/ui/spectroscopy_window.py` stop re-enabling the Refresh button when `refresh_async` reports that a refresh is already in progress so the button remains disabled until the manager emits completion.
- No other functional changes; existing `refresh_async` timeout and completion signal paths are relied on to re-enable the UI and update status.

### Testing
- No automated tests were executed for this change.
- Manual verification is implied by signal/flow adjustments but not recorded as automated tests.
- N/A
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484934c5a083249c473f52bff3c157)