### PR TITLE
Add per-provider timing and detailed error logging for spectrometer enumeration

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -8,6 +8,7 @@ import importlib.util
 import logging
 import threading
 import traceback
+import time
 import numpy as np
 from PySide6 import QtCore
 
@@ -164,11 +165,34 @@ class SpectrometerManager(QtCore.QObject):
             threading.get_ident(),
         )
         devices: List[SpectrometerDescriptor] = []
+        slow_threshold_s = 2.0
         for provider in self._providers:
+            provider_name = provider.__class__.__name__
+            logger.info("Starting spectrometer enumeration for %s", provider_name)
+            start_time = time.perf_counter()
             try:
                 devices.extend(provider.list_devices())
             except BaseException as exc:  # pragma: no cover - defensive
-                logger.warning("Failed to enumerate spectrometers: %s\n%s", exc, traceback.format_exc())
+                logger.warning(
+                    "Spectrometer enumeration failed for %s: %s: %s\n%s",
+                    provider_name,
+                    type(exc).__name__,
+                    exc,
+                    traceback.format_exc(),
+                )
+            finally:
+                elapsed = time.perf_counter() - start_time
+                logger.info(
+                    "Completed spectrometer enumeration for %s in %.2fs",
+                    provider_name,
+                    elapsed,
+                )
+                if elapsed > slow_threshold_s:
+                    logger.warning(
+                        "Spectrometer enumeration slow: %s took %.1fs",
+                        provider_name,
+                        elapsed,
+                    )
         logger.info(
             "[thread=%s] Enumerated %d spectrometer device(s)",
             threading.get_ident(),


### PR DESCRIPTION
### Motivation
- Identify slow providers during spectrometer device enumeration so blocking calls can be diagnosed.
- Capture per-provider elapsed times and provider class names for clearer operational visibility.
- Surface the full exception type and message when a provider enumeration fails rather than a generic error.
- Alert when enumeration calls exceed a threshold (`2.0` seconds) so regressions are obvious in logs.

### Description
- Import `time` and measure each provider `list_devices()` call duration with `time.perf_counter()` and a `slow_threshold_s = 2.0` constant.
- Log before and after each provider call to `list_devices()` including the provider class name and elapsed time in `SpectrometerManager._enumerate_devices`.
- Emit a WARN log `Spectrometer enumeration slow: <Provider> took <n.n>s` when elapsed time exceeds the threshold.
- On exceptions include `type(exc).__name__`, the exception `exc`, and the stack trace in the warning message so failures are fully described.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484d64536c8324a7940d91a95f8ed4)