### PR TITLE
Improve spectrometer enumeration logging

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -173,10 +173,14 @@ class SpectrometerManager(QtCore.QObject):
                 devices.extend(provider.list_devices())
             except BaseException as exc:  # pragma: no cover - defensive
                 logger.warning(
-                    "Spectrometer enumeration failed for %s: %s: %s\n%s",
+                    "Spectrometer enumeration failed for %s (%s: %s)",
                     provider_name,
                     type(exc).__name__,
                     exc,
+                )
+                logger.debug(
+                    "Spectrometer enumeration traceback for %s:\n%s",
+                    provider_name,
                     traceback.format_exc(),
                 )
             finally:


### PR DESCRIPTION
### Motivation
- Make failures in spectrometer backend enumeration easier to identify by surfacing the exception type and message.  
- Preserve full tracebacks for deeper debugging without cluttering standard logs.  
- Ensure existing per-provider timing and slow enumeration warnings remain intact.  

### Description
- Change the exception log in `SpectrometerManager._enumerate_devices` to include the exception type and message in the `logger.warning` call.  
- Move the full traceback output into a `logger.debug` call so the traceback is available at debug level but omitted from standard warnings.  
- Keep per-provider start/completion logs and the slow enumeration warning (threshold `2.0s`) around `provider.list_devices()`.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694853ded96083249694a2b54df28c23)