### PR TITLE
Guard Ocean Optics enumeration in subprocess to avoid UI freeze

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -6,10 +6,11 @@ from typing import Iterable, List, Optional, Protocol, Sequence
 import importlib
 import importlib.util
 import logging
-import threading
-import traceback
+import multiprocessing
 import queue
+import threading
 import time
+import traceback
 import numpy as np
 from PySide6 import QtCore
 
@@ -729,6 +730,17 @@ class MockSpectrometer:
         self._averages = max(1, int(averages))
 
 
+def _ocean_optics_enumerate_worker(
+    result_queue: multiprocessing.Queue,
+) -> None:
+    try:
+        devices = OceanOpticsSpectrometer.enumerate()
+    except BaseException as exc:  # pragma: no cover - defensive
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
+        return
+        result_queue.put(("ok", devices))
+
+
 class OceanOpticsSpectrometerProvider:
     def __init__(self, *, timeout_s: float = 5.0) -> None:
         self._timeout_s = float(timeout_s)
@@ -740,38 +752,33 @@ class OceanOpticsSpectrometerProvider:
 
     def list_devices(self) -> List[SpectrometerDescriptor]:
         self._timed_out = False
-        result_queue: queue.Queue[tuple[List[SpectrometerDescriptor], Optional[BaseException]]] = queue.Queue(
-            maxsize=1
-        )
-
-        def worker() -> None:
-            try:
-                result_queue.put((OceanOpticsSpectrometer.enumerate(), None))
-            except BaseException as exc:  # pragma: no cover - defensive
-                result_queue.put(([], exc))
-
-        thread = threading.Thread(
-            target=worker,
+        ctx = multiprocessing.get_context("spawn")
+        result_queue: multiprocessing.Queue = ctx.Queue(maxsize=1)
+        process = ctx.Process(
+            target=_ocean_optics_enumerate_worker,
+            args=(result_queue,),
             name="OceanOpticsEnumerate",
             daemon=True,
         )
-        thread.start()
-        thread.join(self._timeout_s)
-        if thread.is_alive():
+        process.start()
+        process.join(self._timeout_s)
+        if process.is_alive():
             self._timed_out = True
+            process.terminate()
+            process.join()
             logger.warning(
                 "Ocean Optics backend unresponsive; enumeration timed out after %.1fs",
                 self._timeout_s,
             )
             return []
         try:
-            devices, err = result_queue.get_nowait()
+            status, payload = result_queue.get_nowait()
         except queue.Empty:
             return []
-        if err:
-            logger.warning("Failed to enumerate OceanOptics spectrometers: %s", err)
+        if status == "error":
+            logger.warning("Failed to enumerate OceanOptics spectrometers: %s", payload)
             return []
-        return devices
+        return list(payload)
 
     def connect(self, descriptor: SpectrometerDescriptor) -> OceanOpticsSpectrometer:
         return OceanOpticsSpectrometer(descriptor)


### PR DESCRIPTION
### Motivation
- Refresh was blocking the Qt main thread because the Ocean Optics (seabreeze) `list_devices()` call can hang inside native/driver code. 
- Prior thread-based attempts still allowed native driver hangs to block the process, producing the Windows “Python not responding” dialog. 
- The goal is to isolate the native driver enumeration so a stuck backend cannot freeze the UI. 
- Provide a deterministic timeout and surface a warning when the backend is unresponsive.

### Description
- Move Ocean Optics enumeration into a separate subprocess using `multiprocessing.get_context('spawn')` and a `Queue` to capture results instead of running it in-thread. 
- Add `_ocean_optics_enumerate_worker` helper that calls `OceanOpticsSpectrometer.enumerate()` and returns either `("ok", devices)` or `("error", message)` via the multiprocessing queue. 
- Change `OceanOpticsSpectrometerProvider.list_devices()` to spawn the subprocess, `join()` with a configured timeout, `terminate()` and mark `timed_out` if the process is still alive, and log a warning; on timeout or error it returns an empty list. 
- Update imports to include `multiprocessing` and adjust local queue/exception handling to use the subprocess result payload.

### Testing
- No automated tests were executed as part of this change. 
- Existing unit tests to exercise spectrometer enumeration are present under `tests/test_spectroscopy_devices.py` but were not run. 
- Manual repro guidance: open spectroscopy module and press Refresh to verify the UI no longer hangs indefinitely when the Ocean Optics backend is unresponsive. 
- Logging now emits warnings when the Ocean Optics enumeration times out to aid further diagnosis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694845b363508324aa4793bf7d02db9d)