### PR TITLE
Ensure OceanOptics enumeration always reports success on result queue

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -738,7 +738,7 @@ def _ocean_optics_enumerate_worker(
     except BaseException as exc:  # pragma: no cover - defensive
         result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
         return
-        result_queue.put(("ok", devices))
+    result_queue.put(("ok", devices))
 
 
 class OceanOpticsSpectrometerProvider:


### PR DESCRIPTION
### Motivation
- The Ocean Optics enumeration worker could return without placing a success result on the `result_queue`, leaving the caller with an empty queue and preventing proper device listing.
- The intent is to guarantee a success message `("ok", devices)` is delivered after a successful `OceanOpticsSpectrometer.enumerate()` call.

### Description
- Moved the `result_queue.put(("ok", devices))` call out of the `except` block so it is executed after the `try/except` completes.
- Preserved the existing error path that places `("error", ...)` on the queue and returns early when an exception occurs.
- The change is a single-line indentation fix within `_ocean_optics_enumerate_worker` to make the success message reachable.

### Testing
- No automated tests were run for this change.
- Manual inspection and dry-run commit were performed to verify the modification is syntactically correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694862d24bbc83248434e8476d646fe4)