### PR TITLE
Guard Toupcam streaming state with stream lock

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -460,8 +460,9 @@ class ToupcamCamera:
         if self._cam is None:
             self._open()
 
-        if self._is_streaming:
-            return
+        with self._stream_lock:
+            if self._is_streaming:
+                return
 
         try:
             if self._buf is None:
@@ -478,13 +479,14 @@ class ToupcamCamera:
             except TypeError:
                 self._cam.StartPullModeWithCallback(self._on_event)
             log("Camera: pull mode started")
-            self._is_streaming = True
+            with self._stream_lock:
+                self._is_streaming = True
         except Exception as e:
             log(f"Camera: start_stream error: {e}")
 
     def stop_stream(self):
-        self._is_streaming = False
         with self._stream_lock:
+            self._is_streaming = False
             try:
                 if self._cam:
                     self._cam.Stop()


### PR DESCRIPTION
### Motivation

- Prevent races between the SDK callback and stream control that can lead to crashes when buffers are changed.  
- Ensure `_is_streaming`, `_cam`, `_buf_ptr`, and `_arr` are not observed in inconsistent states by the callback.  
- Make start/stop transitions atomic with respect to the callback so buffers cannot be cleared while the callback runs.  

### Description

- Acquire `self._stream_lock` when checking/early-returning from `start_stream` to avoid a race on `_is_streaming`.  
- Set `self._is_streaming = True` while holding `self._stream_lock` immediately after starting pull-mode.  
- Move `self._is_streaming = False` inside the `with self._stream_lock:` block in `stop_stream` so the flag is cleared before calling `Stop()`/`Close()` and before buffers are nulled.  
- Existing buffer management helpers (`_realloc_buffer` and `_update_dimensions`) already use `self._stream_lock`, so callback and buffer replacement are serialized by the same lock.  

### Testing

- No automated tests were executed for this change.  
- Static inspection and local file checks were performed during the rollout.  
- The patch is limited to synchronization around stream lifecycle methods and does not alter image processing logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694866eaaaf48324b6170db6a0c028f1)