### PR TITLE
Prevent Toupcam callback use-after-free by guarding buffer access

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -398,6 +398,13 @@ class ToupcamCamera:
             try:
                 if evt != getattr(self._tp, "TOUPCAM_EVENT_IMAGE", 0x0001):
                     return
+                if (
+                    not self._is_streaming
+                    or self._cam is None
+                    or self._buf_ptr is None
+                    or self._arr is None
+                ):
+                    return
                 with self._stream_lock:
                     if (
                         not self._is_streaming
@@ -485,8 +492,8 @@ class ToupcamCamera:
             log(f"Camera: start_stream error: {e}")
 
     def stop_stream(self):
+        self._is_streaming = False
         with self._stream_lock:
-            self._is_streaming = False
             try:
                 if self._cam:
                     self._cam.Stop()


### PR DESCRIPTION
### Motivation
- The Toupcam pull-mode callback could run concurrently with teardown and dereference freed buffers, causing access violations.
- The change aims to short-circuit the callback when streaming is stopped or buffers are cleared to avoid use-after-free.

### Description
- Add an early check in the `_on_event` callback to return immediately if `_is_streaming` is false or any of `_cam`, `_buf_ptr`, or `_arr` is `None` before taking the stream lock.
- Ensure existing buffer/stride updates (`_realloc_buffer` / `_update_dimensions`) continue to use `self._stream_lock` to serialize changes with the callback.
- In `stop_stream()`, set `self._is_streaming = False` before acquiring `self._stream_lock`, then stop/close the camera and clear buffers while holding the lock to prevent races with the callback.

### Testing
- No automated tests were run for this change.
- Manual or runtime validation was not performed as part of this commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948683636d883249d54f1a0da4ca6c5)