### PR TITLE
Guard toupcam callback against inactive streams

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -399,11 +399,10 @@ class ToupcamCamera:
             try:
                 if evt != getattr(self._tp, "TOUPCAM_EVENT_IMAGE", 0x0001):
                     return
-                if not self._streaming_event.is_set():
-                    return
                 with self._stream_lock:
                     if (
                         not self._is_streaming
+                        or not self._streaming_event.is_set()
                         or self._cam is None
                         or self._buf_ptr is None
                         or self._arr is None


### PR DESCRIPTION
### Motivation
- Fix a use-after-free / access violation in the Toupcam callback path when the image event fires after streaming was stopped.
- Ensure the callback exits before touching camera or buffer pointers when streaming is not active.

### Description
- Move the `self._streaming_event.is_set()` check inside the `with self._stream_lock:` block and include it in the guarded conditional within `_on_event` so the callback bails out under the same lock.
- This makes the code hold `self._stream_lock` while deciding to call `PullImageV2` and while accessing `self._arr`/buffer state to avoid concurrent buffer free/races.
- Changed file: `microstage_app/devices/camera_toupcam.py`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486ae6520883249cee44e5f85961f8)