### PR TITLE
Stop Toupcam streaming cleanly after callback failures

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -394,6 +394,8 @@ class ToupcamCamera:
         self._init_usb_and_speed()
 
         def _on_event(evt, ctx=None):
+            if not self._is_streaming:
+                return
             if self._cb_thread is None:
                 self._cb_thread = threading.current_thread()
             try:
@@ -469,6 +471,24 @@ class ToupcamCamera:
             self._is_streaming = False
             self._streaming_event.clear()
         log(f"Camera: streaming disabled ({reason})")
+        self._detach_callback()
+        try:
+            if self._cam:
+                self._cam.Stop()
+                log("Camera: stopped")
+        except Exception as e:
+            log(f"Camera: stop error: {e}")
+
+    def _detach_callback(self):
+        if not self._cam or not hasattr(self._cam, "StartPullModeWithCallback"):
+            return
+        try:
+            try:
+                self._cam.StartPullModeWithCallback(None, self)
+            except TypeError:
+                self._cam.StartPullModeWithCallback(None)
+        except Exception as e:
+            log(f"Camera: detach callback failed: {e}")
 
     # ---------------- public API used by UI ----------------
 
@@ -505,8 +525,10 @@ class ToupcamCamera:
             log(f"Camera: start_stream error: {e}")
 
     def stop_stream(self):
-        self._is_streaming = False
-        self._streaming_event.clear()
+        with self._stream_lock:
+            self._is_streaming = False
+            self._streaming_event.clear()
+        self._detach_callback()
         with self._stream_lock:
             try:
                 if self._cam:


### PR DESCRIPTION
### Motivation
- Prevent pull-mode callbacks from running after catastrophic `PullImageV2` failures which can lead to access-violation crashes.
- Ensure the streaming state is cleared before stopping or closing the SDK camera object.
- Avoid the callback re-arming itself and automatically restarting pull mode after a failure so the UI must explicitly restart streaming.
- Detach the SDK callback when stopping if the wrapper supports removing/clearing the callback.

### Description
- Added an early guard in `_on_event` to immediately return when `self._is_streaming` is false to avoid executing callback logic when streaming is disabled.
- Modified `_disable_streaming` to clear streaming flags, call a new `_detach_callback` helper, and call `self._cam.Stop()` when available to stop the SDK stream on errors.
- Implemented `_detach_callback` which attempts to call `StartPullModeWithCallback(None, ...)` (with a `TypeError` fallback) to remove the SDK callback if supported.
- Reworked `stop_stream` to set `self._is_streaming = False` under lock and detach the callback prior to invoking `Stop`/`Close` and clearing camera buffers.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486c2c65f083248e5ee3cae110f4e3)