### PR TITLE
Preserve Toupcam pixel format state on failures

### DIFF
--- a/microstage_app/devices/camera_toupcam.py
+++ b/microstage_app/devices/camera_toupcam.py
@@ -743,6 +743,9 @@ class ToupcamCamera:
         depth = int(depth)
         if depth not in self._color_depths:
             return
+        prev_raw_mode = self._raw_mode
+        prev_bits = self._bits
+        prev_color_depth = self._color_depth
         updated = False
         try:
             if hasattr(self._cam, "put_Option") and hasattr(self._tp, "TOUPCAM_OPTION_BITDEPTH"):
@@ -765,6 +768,14 @@ class ToupcamCamera:
         finally:
             if not updated:
                 try:
+                    self._raw_mode = prev_raw_mode
+                    self._bits = prev_bits
+                    self._color_depth = prev_color_depth
+                    if hasattr(self._cam, "put_Option") and hasattr(self._tp, "TOUPCAM_OPTION_BITDEPTH"):
+                        self._cam.put_Option(
+                            self._tp.TOUPCAM_OPTION_BITDEPTH,
+                            1 if prev_color_depth > 8 else 0,
+                        )
                     self._update_dimensions()
                 except Exception:
                     pass
@@ -875,6 +886,9 @@ class ToupcamCamera:
                 self._is_streaming = True
 
     def set_raw_fast_mono(self, enable: bool):
+        prev_raw_mode = self._raw_mode
+        prev_bits = self._bits
+        prev_color_depth = self._color_depth
         self._raw_mode = bool(enable)
         self._bits = 16 if (self._raw_mode and self._color_depth > 8) else (
             8 if self._raw_mode else 24
@@ -898,6 +912,10 @@ class ToupcamCamera:
         finally:
             if not updated:
                 try:
+                    self._raw_mode = prev_raw_mode
+                    self._bits = prev_bits
+                    self._color_depth = prev_color_depth
+                    self._force_rgb_or_raw()
                     self._update_dimensions()
                 except Exception:
                     pass


### PR DESCRIPTION
### Motivation

- Avoid leaving the camera object in an inconsistent state when pixel format changes fail. 
- Ensure buffer dimensions and internal flags (`_raw_mode`, `_bits`, `_color_depth`) match the actual SDK state. 
- Provide safer handling around `._set_pixel_format(...)` failures so callers see a consistent camera configuration. 

### Description

- Capture prior values of `self._raw_mode`, `self._bits`, and `self._color_depth` at the start of `set_color_depth` and `set_raw_fast_mono`. 
- If `_set_pixel_format(...)` does not report success, restore the saved `self._raw_mode`, `self._bits`, and `self._color_depth`. 
- When reverting in `set_color_depth`, also attempt to restore the SDK bit-depth via `put_Option(self._tp.TOUPCAM_OPTION_BITDEPTH, ...)` and call `self._update_dimensions()` so buffers match the real output. 
- When reverting in `set_raw_fast_mono`, call `self._force_rgb_or_raw()` and `self._update_dimensions()` to synchronize SDK/raw option and buffer size. 

### Testing

- No automated tests were executed as part of this change. 
- Basic health checks: repository file updated and committed successfully. 
- No new unit tests were added. 
- Manual runtime validation is recommended on hardware to confirm behavior under failing `_set_pixel_format` conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694872e4fdf483248024fe0f1f9e7692)