### PR TITLE
Avoid multiprocessing for OceanOptics enumeration on worker threads (Windows)

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -8,6 +8,7 @@ import importlib.util
 import logging
 import multiprocessing
 import queue
+import sys
 import threading
 import time
 import traceback
@@ -807,6 +808,18 @@ class OceanOpticsSpectrometerProvider:
 
     def list_devices(self) -> List[SpectrometerDescriptor]:
         self._timed_out = False
+        if (
+            sys.platform == "win32"
+            and threading.current_thread() is not threading.main_thread()
+        ):
+            try:
+                return list(OceanOpticsSpectrometer.enumerate())
+            except BaseException as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "Failed to enumerate OceanOptics spectrometers: %s",
+                    f"{type(exc).__name__}: {exc}",
+                )
+                return []
         ctx = multiprocessing.get_context("spawn")
         result_queue: multiprocessing.Queue = ctx.Queue(maxsize=1)
         process = ctx.Process(


### PR DESCRIPTION
### Motivation

- Prevent use of `multiprocessing` when `OceanOpticsSpectrometer` enumeration is invoked from a non-main thread on Windows to avoid spawn/IPC issues and hangs.
- Preserve the existing watchdog/timeout behaviour for main-thread enumeration by keeping the spawned-process path.

### Description

- Added `import sys` and a conditional in `OceanOpticsSpectrometerProvider.list_devices` that checks `sys.platform == "win32"` and `threading.current_thread() is not threading.main_thread()`.
- When the condition is met, the code now calls `OceanOpticsSpectrometer.enumerate()` directly and logs and returns an empty list on exceptions. 
- Left the original `multiprocessing`-based spawn worker and timeout/watchdog path intact for main-thread usage.
- Changes are localized to `microstage_app/spectroscopy/devices.py` in the `OceanOpticsSpectrometerProvider.list_devices` implementation.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948772f2ffc832495fb06f332bf5952)