### PR TITLE
Fix spectrometer enumeration finally alignment

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -207,6 +207,9 @@ class SpectrometerManager(QtCore.QObject):
                     provider_devices = self._provider_devices.get(provider, [])
                 else:
                     self._provider_devices[provider] = list(provider_devices)
+                devices.extend(provider_devices)
+                for descriptor in provider_devices:
+                    device_providers[descriptor] = provider
             except BaseException as exc:  # pragma: no cover - defensive
                 provider_devices = self._provider_devices.get(provider, [])
                 logger.warning(
@@ -220,9 +223,9 @@ class SpectrometerManager(QtCore.QObject):
                     provider_name,
                     traceback.format_exc(),
                 )
-            devices.extend(provider_devices)
-            for descriptor in provider_devices:
-                device_providers[descriptor] = provider
+                devices.extend(provider_devices)
+                for descriptor in provider_devices:
+                    device_providers[descriptor] = provider
             finally:
                 elapsed = time.perf_counter() - start_time
                 logger.info(


### PR DESCRIPTION
### Motivation
- Fix incorrect indentation in `_enumerate_devices` so the `finally` block is paired with the `try` that wraps provider enumeration.
- Ensure provider device aggregation (`devices.extend(...)` and the `for descriptor in provider_devices` mapping) is performed inside the provider `try`/`except` handling so fallback values are used on errors or timeouts.
- Prevent misaligned `finally` from causing control-flow issues during provider enumeration.
- Improve robustness and correctness of spectrometer provider enumeration.

### Description
- Moved `devices.extend(provider_devices)` and the `for descriptor in provider_devices` mapping into both the `try` and `except` branches inside `_enumerate_devices`.
- Aligned the `finally:` with the `try:` that wraps the provider enumeration so elapsed timing and logging always execute for each provider.
- Preserved existing timeout fallback where `provider_devices` is taken from cached `_provider_devices` when a provider times out or raises an exception.
- No other functional changes to returned device list semantics.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948781908dc8324998d53e361e686a4)