### PR TITLE
Avoid multiprocessing in background OceanOptics enumeration

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -811,10 +811,32 @@ class OceanOpticsSpectrometerProvider:
 
     def list_devices(self) -> List[SpectrometerDescriptor]:
         self._timed_out = False
-        if (
-            sys.platform == "win32"
-            and threading.current_thread() is not threading.main_thread()
-        ):
+        is_main_thread = threading.current_thread() is threading.main_thread()
+        is_windows = sys.platform == "win32"
+        if not is_main_thread:
+            app = QtCore.QCoreApplication.instance() if is_windows else None
+            if app is not None:
+                result: dict[str, object] = {"devices": None, "error": None}
+
+                def _enumerate_on_main_thread() -> None:
+                    try:
+                        result["devices"] = list(OceanOpticsSpectrometer.enumerate())
+                    except BaseException as exc:  # pragma: no cover - defensive
+                        result["error"] = exc
+
+                QtCore.QMetaObject.invokeMethod(
+                    app,
+                    _enumerate_on_main_thread,
+                    QtCore.Qt.BlockingQueuedConnection,
+                )
+                if result["error"] is not None:
+                    exc = result["error"]
+                    logger.warning(
+                        "Failed to enumerate OceanOptics spectrometers: %s",
+                        f"{type(exc).__name__}: {exc}",
+                    )
+                    return []
+                return list(result["devices"] or [])
             try:
                 return list(OceanOpticsSpectrometer.enumerate())
             except BaseException as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
### Motivation
- Prevent background threads (e.g. refresh QThread) from attempting to spawn a process and hanging during Ocean Optics enumeration on Windows.
- Preserve existing timeout-based, process-isolated enumeration for calls made on the main thread to retain robustness against unresponsive backends.
- Detect thread and platform context so enumeration can be marshaled or simplified as appropriate.

### Description
- Updated `microstage_app/spectroscopy/devices.py` to change `OceanOpticsSpectrometerProvider.list_devices()` behavior when called off the main thread.
- Add detection using `threading.current_thread() is threading.main_thread()` and `sys.platform == "win32"` to decide enumeration strategy.
- When off the main thread and a `QCoreApplication` instance exists on Windows, marshal `OceanOpticsSpectrometer.enumerate()` to the main thread using `QtCore.QMetaObject.invokeMethod` with `QtCore.Qt.BlockingQueuedConnection`; otherwise call `OceanOpticsSpectrometer.enumerate()` directly without using `multiprocessing`.
- Retain the existing `multiprocessing`-based spawn, timeout, and termination logic for main-thread calls to keep the process-based safeguard.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69487a293e048324a873482d44470b2b)