### PR TITLE
Fix Ocean Optics invokeMethod usage

### DIFF
--- a/microstage_app/spectroscopy/devices.py
+++ b/microstage_app/spectroscopy/devices.py
@@ -816,27 +816,34 @@ class OceanOpticsSpectrometerProvider:
         if not is_main_thread:
             app = QtCore.QCoreApplication.instance() if is_windows else None
             if app is not None:
-                result: dict[str, object] = {"devices": None, "error": None}
+                class _EnumHelper(QtCore.QObject):
+                    def __init__(self) -> None:
+                        super().__init__()
+                        self.devices: List[SpectrometerDescriptor] = []
+                        self.error: Optional[BaseException] = None
 
-                def _enumerate_on_main_thread() -> None:
-                    try:
-                        result["devices"] = list(OceanOpticsSpectrometer.enumerate())
-                    except BaseException as exc:  # pragma: no cover - defensive
-                        result["error"] = exc
+                    @QtCore.Slot()
+                    def run(self) -> None:
+                        try:
+                            self.devices = list(OceanOpticsSpectrometer.enumerate())
+                        except BaseException as exc:  # pragma: no cover - defensive
+                            self.error = exc
 
+                helper = _EnumHelper()
+                helper.moveToThread(app.thread())
                 QtCore.QMetaObject.invokeMethod(
-                    app,
-                    _enumerate_on_main_thread,
+                    helper,
+                    "run",
                     QtCore.Qt.BlockingQueuedConnection,
                 )
-                if result["error"] is not None:
-                    exc = result["error"]
+                if helper.error is not None:
+                    exc = helper.error
                     logger.warning(
                         "Failed to enumerate OceanOptics spectrometers: %s",
                         f"{type(exc).__name__}: {exc}",
                     )
                     return []
-                return list(result["devices"] or [])
+                return list(helper.devices or [])
             try:
                 return list(OceanOpticsSpectrometer.enumerate())
             except BaseException as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
### Motivation

- The previous code passed a Python callable to `QtCore.QMetaObject.invokeMethod`, which is an invalid Qt signature and could fail when moving work to the main thread. 
- Enumeration of Ocean Optics spectrometers must run on the Qt main thread on Windows to avoid threading issues. 
- Replace the ad-hoc dict/lambda approach with a proper `QObject` slot so `invokeMethod` receives a valid member name.

### Description

- Added an internal `_EnumHelper` subclass of `QtCore.QObject` with a `@QtCore.Slot()` method `run()` that performs `OceanOpticsSpectrometer.enumerate()` and stores results and errors. 
- Moved the helper to the application thread with `helper.moveToThread(app.thread())` and invoked it via `QtCore.QMetaObject.invokeMethod(helper, "run", QtCore.Qt.BlockingQueuedConnection)`. 
- Replaced the previous result-dict / Python-callable invocation flow with the helper, returning `list(helper.devices or [])` and preserving error logging. 
- Change applied in `microstage_app/spectroscopy/devices.py` to ensure correct Qt signature and blocking queued execution.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69487bb31fe883248abfcbf31d893c44)